### PR TITLE
(Start of) TypeScript port and code splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 backup/
 three revisions/
 three-*.js
+.DS_Store
 # TODO: temporary
 docs/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "name": "ffl.js",
       "license": "AGPL-3.0-only",
+      "dependencies": {
+        "three": "^0.180.0"
+      },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
         "@eslint/js": "^9.20.0",
@@ -16,7 +19,8 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsdoc": "^50.6.3",
         "globals": "^15.15.0",
-        "tsconfig-paths": "^4.2.0"
+        "tsconfig-paths": "^4.2.0",
+        "tsup": "^8.5.0"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
@@ -32,6 +36,448 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
@@ -318,6 +764,63 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -353,6 +856,17 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
@@ -365,6 +879,314 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -399,10 +1221,11 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -599,6 +1422,19 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -613,6 +1449,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/are-docs-informative": {
       "version": "0.0.2",
@@ -796,6 +1639,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -869,6 +1738,22 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -887,6 +1772,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/comment-parser": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
@@ -902,6 +1797,23 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1051,6 +1963,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-abstract": {
       "version": "1.23.9",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
@@ -1195,6 +2121,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1613,6 +2581,24 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -1660,6 +2646,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -1692,6 +2690,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1784,6 +2814,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -2125,6 +3176,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
@@ -2340,6 +3401,32 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2417,6 +3504,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2437,6 +3554,30 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -2513,17 +3654,62 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -2680,6 +3866,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2731,16 +3924,70 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -2750,6 +3997,49 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/prelude-ls": {
@@ -2790,6 +4080,20 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -2871,6 +4175,48 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.4",
+        "@rollup/rollup-android-arm64": "4.52.4",
+        "@rollup/rollup-darwin-arm64": "4.52.4",
+        "@rollup/rollup-darwin-x64": "4.52.4",
+        "@rollup/rollup-freebsd-arm64": "4.52.4",
+        "@rollup/rollup-freebsd-x64": "4.52.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
+        "@rollup/rollup-linux-arm64-musl": "4.52.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-musl": "4.52.4",
+        "@rollup/rollup-openharmony-arm64": "4.52.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
+        "@rollup/rollup-win32-x64-gnu": "4.52.4",
+        "@rollup/rollup-win32-x64-msvc": "4.52.4",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
@@ -3099,12 +4445,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/slashes": {
       "version": "3.0.12",
       "resolved": "https://registry.npmjs.org/slashes/-/slashes-3.0.12.tgz",
       "integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
@@ -3130,6 +4503,70 @@
       "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
@@ -3187,6 +4624,46 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -3207,6 +4684,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/supports-color": {
@@ -3250,6 +4750,59 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3260,6 +4813,26 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3273,6 +4846,13 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
@@ -3295,6 +4875,69 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.0.tgz",
+      "integrity": "sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.25.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "0.8.0-beta.0",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3396,6 +5039,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -3429,6 +5079,25 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/which": {
@@ -3537,6 +5206,101 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "ffl.js",
+      "license": "AGPL-3.0-only",
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
         "@eslint/js": "^9.20.0",
@@ -53,10 +54,11 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -92,10 +94,11 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
@@ -106,10 +109,11 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -120,6 +124,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -127,11 +132,25 @@
         "node": "*"
       }
     },
-    "node_modules/@eslint/core": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.11.0.tgz",
-      "integrity": "sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==",
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.0.tgz",
+      "integrity": "sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.16.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
+      "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -140,10 +159,11 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -163,10 +183,11 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -177,6 +198,7 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -189,6 +211,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -197,12 +220,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.20.0.tgz",
-      "integrity": "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==",
+      "version": "9.37.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.37.0.tgz",
+      "integrity": "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -210,30 +237,20 @@
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
       "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
-      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz",
+      "integrity": "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.10.0",
+        "@eslint/core": "^0.16.0",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
-      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -288,10 +305,11 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
@@ -390,7 +408,8 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -542,10 +561,11 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -567,6 +587,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -607,7 +628,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -753,10 +775,11 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -825,6 +848,7 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1186,21 +1210,23 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.20.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.20.1.tgz",
-      "integrity": "sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==",
+      "version": "9.37.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
+      "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.11.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.20.0",
-        "@eslint/plugin-kit": "^0.2.5",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.4.0",
+        "@eslint/core": "^0.16.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.37.0",
+        "@eslint/plugin-kit": "^0.4.0",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -1208,9 +1234,9 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.2.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1324,10 +1350,11 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1416,10 +1443,11 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -1432,10 +1460,11 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1444,10 +1473,11 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1466,14 +1496,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1499,6 +1530,7 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -1528,7 +1560,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1562,7 +1595,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -1905,6 +1939,7 @@
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -2310,6 +2345,7 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2337,7 +2373,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2648,6 +2685,7 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -2728,6 +2766,7 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2819,6 +2858,7 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -3161,6 +3201,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -3385,6 +3426,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": "./ffl.js"
   },
+  "type": "module",
   "author": "Arian Kordi",
   "license": "AGPL-3.0-only",
   "bugs": {
@@ -31,6 +32,10 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsdoc": "^50.6.3",
     "globals": "^15.15.0",
-    "tsconfig-paths": "^4.2.0"
+    "tsconfig-paths": "^4.2.0",
+    "tsup": "^8.5.0"
+  },
+  "dependencies": {
+    "three": "^0.180.0"
   }
 }

--- a/src/Body.ts
+++ b/src/Body.ts
@@ -1,0 +1,15 @@
+import * as THREE from 'three';
+
+export enum PantsColor {
+	GrayNormal = 0,
+	BluePresent = 1,
+	RedRegular = 2,
+	GoldSpecial = 3
+};
+
+export const pantsColors: Record<PantsColor, THREE.Color> = {
+	[PantsColor.GrayNormal]: new THREE.Color(0x40474E),
+	[PantsColor.BluePresent]: new THREE.Color(0x28407A),
+	[PantsColor.RedRegular]: new THREE.Color(0x702015),
+	[PantsColor.GoldSpecial]: new THREE.Color(0xC0A030)
+};

--- a/src/CharInfo.ts
+++ b/src/CharInfo.ts
@@ -1,0 +1,254 @@
+import Module from './Module';
+import { FFLExpression } from "./enums";
+import { FFLiVerifyReasonException } from "./Exceptions";
+import { FFLAge, FFLDataSource, FFLGender, FFLiCharInfo, FFLRace, FFLStoreData_size, FFLCharModelSource } from "./StructFFLiCharModel";
+import { convertStudioCharInfoToFFLiCharInfo, StudioCharInfo, studioURLObfuscationDecode } from './StudioCharInfo';
+import {  } from './StructFFLiCharModel'
+
+/**
+ * Converts the input data and allocates it into FFLCharModelSource.
+ * Note that this allocates pBuffer so you must free it when you are done.
+ * @param {Uint8Array|FFLiCharInfo} data - Input: FFLStoreData, FFLiCharInfo (as Uint8Array and object), StudioCharInfo
+ * @param {Module} module - Module to allocate and access the buffer through.
+ * @returns {FFLCharModelSource} The CharModelSource with the data specified.
+ * @throws {Error} data must be Uint8Array or FFLiCharInfo object. Data must be a known type.
+ * @package
+ */
+export function _allocateModelSource(data: Uint8Array | typeof FFLiCharInfo, module: Module): ReturnType<typeof FFLCharModelSource.unpack> {
+	/** Maximum size. */
+	const bufferPtr = module._malloc(FFLiCharInfo.size);
+
+	// Create modelSource.
+	const modelSource = {
+		// FFLDataSource.BUFFER = copies and verifies
+		// FFLDataSource.DIRECT_POINTER = use without verification.
+		dataSource: FFLDataSource.DIRECT_POINTER, // Assumes CharInfo by default.
+		pBuffer: bufferPtr,
+		index: 0 // unneeded for raw data
+	};
+
+	// module._FFLiGetRandomCharInfo(bufferPtr, FFLGender.FEMALE, FFLAge.ALL, FFLRace.WHITE); return modelSource;
+
+	// Check type of data.
+	if (!(data instanceof Uint8Array)) {
+		try {
+			if (typeof data !== 'object') {
+				throw new Error('_allocateModelSource: data passed in is not FFLiCharInfo object or Uint8Array');
+			}
+			// Assume that this is FFLiCharInfo as an object.
+			// Deserialize to Uint8Array.
+			data = FFLiCharInfo.pack(data);
+		} catch (e) {
+			module._free(bufferPtr);
+			throw e;
+		}
+	}
+
+	/** @param {Uint8Array} src - Source data in {@link StudioCharInfo} format. */
+	function setStudioData(src: Uint8Array): void {
+		// studio raw, decode it to charinfo
+		const studio = StudioCharInfo.unpack(src);
+		const charInfo = convertStudioCharInfoToFFLiCharInfo(studio);
+		data = FFLiCharInfo.pack(charInfo);
+		module.HEAPU8.set(data, bufferPtr);
+	}
+
+	/**
+	 * Gets CharInfo from calling a function.
+	 * @param {Uint8Array} data - The input data.
+	 * @param {number} size - The size to allocate.
+	 * @param {string} funcName - The function on the module to call.
+	 * @throws {Error} Throws if the function returned false.
+	 * @private
+	 */
+	function callGetCharInfoFunc(data: Uint8Array, size: number, funcName: string): void {
+		const dataPtr = module._malloc(size);
+		module.HEAPU8.set(data, dataPtr);
+		// @ts-ignore - Module cannot be indexed by string. NOTE: The function MUST exist.
+		const result = module[funcName](bufferPtr, dataPtr);
+		module._free(dataPtr);
+		if (!result) {
+			module._free(bufferPtr);
+			throw new Error(`_allocateModelSource: call to ${funcName} returned false, CharInfo verification probably failed`);
+		}
+	}
+
+	// data should be Uint8Array at this point.
+
+	// Enumerate through supported data types.
+	switch (data.length) {
+		case FFLStoreData_size: { // sizeof(FFLStoreData)
+			// modelSource.dataSource = FFLDataSource.STORE_DATA;
+			// Convert FFLStoreData to FFLiCharInfo instead.
+			callGetCharInfoFunc(data, FFLStoreData_size, '_FFLpGetCharInfoFromStoreData');
+			break;
+		}
+		case 74: // sizeof(RFLCharData)
+		case 76: { // sizeof(RFLStoreData)
+			callGetCharInfoFunc(data, 74, '_FFLpGetCharInfoFromMiiDataOfficialRFL');
+			break;
+		}
+		case FFLiCharInfo.size:
+			// modelSource.dataSource = FFLDataSource.BUFFER; // Default option.
+			module.HEAPU8.set(data, bufferPtr); // Copy data into heap.
+			break;
+		case StudioCharInfo.size + 1: {
+			// studio data obfuscated
+			data = studioURLObfuscationDecode(data);
+			setStudioData(data);
+			break;
+		}
+		case StudioCharInfo.size: {
+			// studio data raw
+			setStudioData(data);
+			break;
+		}
+		// Unsupported types.
+		case 88:
+			throw new Error('_allocateModelSource: NX CharInfo is not supported.');
+		case 48:
+		case 68:
+			throw new Error('_allocateModelSource: NX CoreData/StoreData is not supported.');
+		case 92:
+		case 72:
+			throw new Error('_allocateModelSource: Please convert your FFLiMiiDataOfficial/FFLiMiiDataCore to FFLStoreData (add a checksum).');
+		default: {
+			module._free(bufferPtr);
+			throw new Error(`_allocateModelSource: Unknown length for character data: ${data.length}`);
+		}
+	}
+
+	return modelSource; // NOTE: pBuffer must be freed.
+}
+
+// ----------------- verifyCharInfo(data, module, verifyName) -----------------
+/**
+ * Validates the input CharInfo by calling FFLiVerifyCharInfoWithReason.
+ * @param {Uint8Array|number} data - FFLiCharInfo structure as bytes or pointer.
+ * @param {Module} module - Module to access the data and call FFL through.
+ * @param {boolean} verifyName - Whether the name and creator name should be verified.
+ * @returns {void} Returns nothing if verification passes.
+ * @throws {FFLiVerifyReasonException} Throws if the result is not 0 (FFLI_VERIFY_REASON_OK).
+ * @public
+ */
+export function verifyCharInfo(data: Uint8Array | number, module: Module, verifyName = false): void {
+	// Resolve charInfoPtr as pointer to CharInfo.
+	let charInfoPtr = 0;
+	let charInfoAllocated = false;
+	// Assume that number means pointer.
+	if (typeof data === 'number') {
+		charInfoPtr = data;
+		charInfoAllocated = false;
+	} else {
+		// Assume everything else means Uint8Array. TODO: untested
+		charInfoAllocated = true;
+		// Allocate and copy CharInfo.
+		charInfoPtr = module._malloc(FFLiCharInfo.size);
+		module.HEAPU8.set(data, charInfoPtr);
+	}
+	const result = module._FFLiVerifyCharInfoWithReason(charInfoPtr, verifyName);
+	// Free CharInfo as soon as the function returns.
+	if (charInfoAllocated) {
+		module._free(charInfoPtr);
+	}
+
+	if (result !== 0) {
+		// Reference: https://github.com/aboood40091/ffl/blob/master/include/nn/ffl/detail/FFLiCharInfo.h#L90
+		throw new FFLiVerifyReasonException(result);
+	}
+}
+
+// --------------- getRandomCharInfo(module, gender, age, race) ---------------
+/**
+ * Generates a random FFLiCharInfo instance calling FFLiGetRandomCharInfo.
+ * @param {Module} module - The Emscripten module.
+ * @param {FFLGender} gender - Gender of the character.
+ * @param {FFLAge} age - Age of the character.
+ * @param {FFLRace} race - Race of the character.
+ * @returns {Uint8Array} The random FFLiCharInfo.
+ * @todo TODO: Should this return FFLiCharInfo object?
+ */
+export function getRandomCharInfo(module: Module, gender = FFLGender.ALL, age = FFLAge.ALL, race = FFLRace.ALL): Uint8Array {
+	const ptr = module._malloc(FFLiCharInfo.size);
+	module._FFLiGetRandomCharInfo(ptr, gender, age, race);
+	const result = module.HEAPU8.slice(ptr, ptr + FFLiCharInfo.size);
+	module._free(ptr);
+	return result;
+}
+
+/**
+ * Checks if the expression index disables any shapes in the
+ * CharModel, meant to be used when setting multiple indices.
+ * @param {FFLExpression} i - Expression index to check.
+ * @param {boolean} [warn] - Whether to log using {@link console.warn}.
+ * @returns {boolean} Whether the expression changes shapes.
+ */
+export function checkExpressionChangesShapes(i: number, warn = false): boolean {
+	/** Expressions disabling nose: dog/cat, blank */
+	const expressionsDisablingNose = [49, 50, 51, 52, 61, 62];
+	/** Expressions disabling mask: blank */
+	const expressionsDisablingMask = [61, 62];
+
+	const prefix = `checkExpressionChangesShapes: An expression was enabled (${i}) that is meant to disable nose or mask shape for the entire CharModel, so it is only recommended to set this as a single expression rather than as one of multiple.`;
+	if (expressionsDisablingMask.indexOf(i) !== -1) {
+		warn && console.warn(`${prefix} (in this case, MASK SHAPE so there is supposed to be NO FACE)`);
+		return true;
+	}
+	if (expressionsDisablingNose.indexOf(i) !== -1) {
+		warn && console.warn(`${prefix} (nose shape)`);
+		return true;
+	}
+
+	return false;
+}
+
+// --------------------- makeExpressionFlag(expressions) ----------------------
+/**
+ * Creates an expression flag to be used in FFLCharModelDesc.
+ * Use this whenever you need to describe which expression,
+ * or expressions, you want to be able to use in the CharModel.
+ * @param {Array<FFLExpression>|FFLExpression} expressions - Either a single expression
+ * index or an array of expression indices. See {@link FFLExpression} for min/max.
+ * @returns {Uint32Array} FFLAllExpressionFlag type of three 32-bit integers.
+ * @throws {Error} expressions must be in range and less than {@link FFLExpression.MAX}.
+ */
+export function makeExpressionFlag(expressions: FFLExpression | FFLExpression[]): Uint32Array {
+	/**
+	 * @param {FFLExpression} i - Expression index to check.
+	 * @throws {Error} input out of range
+	 */
+	function checkRange(i: FFLExpression): void {
+		if (i >= FFLExpression.MAX) {
+			throw new Error(`makeExpressionFlag: input out of range: got ${i}, max: ${FFLExpression.MAX}`);
+		}
+	}
+
+	/** FFLAllExpressionFlag */
+	const flags = new Uint32Array([0, 0, 0]);
+	let checkForChangeShapes = true;
+
+	// Set single expression.
+	if (typeof expressions === 'number') {
+		// Make expressions into an array.
+		expressions = [expressions];
+		checkForChangeShapes = false; // Single expression, do not check this
+		// Fall-through.
+	} else if (!Array.isArray(expressions)) {
+		throw new Error('makeExpressionFlag: expected array or single number');
+	}
+
+	// Set multiple expressions in an array.
+	for (const index of expressions) {
+		checkRange(index);
+		if (checkForChangeShapes) {
+			checkExpressionChangesShapes(index, true); // Warn if the expression changes shapes.
+		}
+		/** Determine which 32-bit block. */
+		const part = Math.floor(index / 32);
+		/** Determine the bit within the block. */
+		const bitIndex = index % 32;
+
+		flags[part] |= (1 << bitIndex); // Set the bit.
+	}
+	return flags;
+}

--- a/src/CharInfo.ts
+++ b/src/CharInfo.ts
@@ -1,9 +1,9 @@
-import Module from './Module';
-import { FFLExpression } from "./enums";
-import { FFLiVerifyReasonException } from "./Exceptions";
-import { FFLAge, FFLDataSource, FFLGender, FFLiCharInfo, FFLRace, FFLStoreData_size, FFLCharModelSource } from "./StructFFLiCharModel";
-import { convertStudioCharInfoToFFLiCharInfo, StudioCharInfo, studioURLObfuscationDecode } from './StudioCharInfo';
-import {  } from './StructFFLiCharModel'
+import { Module } from '@/Module';
+import { FFLExpression } from "@/enums";
+import { FFLiVerifyReasonException } from "@/Exceptions";
+import { FFLAge, FFLDataSource, FFLGender, FFLiCharInfo, FFLRace, FFLStoreData_size, FFLCharModelSource } from "@/StructFFLiCharModel";
+import { convertStudioCharInfoToFFLiCharInfo, StudioCharInfo, studioURLObfuscationDecode } from '@/StudioCharInfo';
+import {  } from '@/StructFFLiCharModel'
 
 /**
  * Converts the input data and allocates it into FFLCharModelSource.

--- a/src/CharModel.ts
+++ b/src/CharModel.ts
@@ -1,0 +1,609 @@
+import * as THREE from 'three';
+import Module from './Module';
+import TextureManager from './TextureManager';
+import { FFLExpression, FFLiShapeType, FFLModelFlag, FFLModulateType } from './enums';
+import { FFL_RESOLUTION_MASK, FFLCharModelDesc, FFLiCharInfo, FFLiCharModel, FFLiMaskTexturesTempObject, FFLiTextureTempObject, FFLStoreData_size, FFLPartsTransform } from './StructFFLiCharModel';
+import { _getFFLColor, _getFFLColor3, drawParamToMesh } from './DrawParam';
+import { FFLVec3 } from '../ffl-original';
+import { FFLColor } from './structs';
+import { disposeMany } from './RenderTargetUtils';
+import { ExpressionNotSet } from './Exceptions';
+import { PantsColor } from './Body';
+import SampleShaderMaterialColorInfo from './materials/SampleShaderMaterialColorInfo';
+
+export type MaterialConstructor = new (...args: any[]) => THREE.Material;
+
+
+// --------------------------- Class: CharModel -------------------------------
+/**
+ * Represents an FFLCharModel, which is the head model.
+ * Encapsulates a pointer to the underlying instance and provides helper methods.
+ *
+ * NOTE: This is a wrapper around CharModel. In order to create one,
+ * either call createCharModel or pass the pointer of a manually created
+ * CharModel in here. So *DO NOT* call this constructor directly!
+ * @public
+ */
+export default class CharModel {
+	/** Permanent reference to the original pointer. */
+	private __ptr: number;
+	private _facelineColor?: THREE.Color;
+	private _favoriteColor?: THREE.Color;
+	private _boundingBox?: THREE.Box3;
+	private _partsTransform?: ReturnType<typeof FFLPartsTransform.unpack>;
+
+	/**
+	 * The unpacked representation of the underlying
+	 * FFLCharModel instance. Note that this is not
+	 * meant to be updated at all and changes to
+	 * this instance will not apply in FFL whatsoever.
+	 */
+	public readonly _model: ReturnType<typeof FFLiCharModel.unpack>;
+
+	/** The {@link TextureManager} instance for this CharModel. */
+	public _textureManager: TextureManager;
+
+	/**
+	 * The data used to construct the CharModel, set in {@link createCharModel} and used in {@link updateCharModel}.
+	 */
+	public _data: any;
+
+	/**
+	 * Pointer to the FFLiCharModel in memory, set to null when deleted.
+	 */
+	public _ptr: number | null;
+
+	/** The Emscripten module. */
+	public _module: Module;
+
+	/** RenderTarget for faceline. */
+	public _facelineTarget: THREE.RenderTarget | null;
+
+	/** RenderTargets for each expression mask. */
+	public _maskTargets: (THREE.RenderTarget | null)[];
+
+	/**
+	 * Material class used for the CharModel.
+	 */
+	public _materialClass: MaterialConstructor;
+
+	/**
+	 * Material class used to initialize textures specifically.
+	 */
+	public _materialTextureClass: MaterialConstructor;
+
+	/**
+	 * List of enabled expressions that can be set with {@link CharModel.setExpression}.
+	 */
+	public expressions: Array<FFLExpression>;
+
+	/**
+	 * Group of THREE.Mesh objects representing the CharModel.
+	 */
+	public meshes: THREE.Group;
+
+	public _facelineMesh?: THREE.Mesh | null;
+	public _maskMesh?: THREE.Mesh | null;
+
+	/**
+	 * @param {number} ptr - Pointer to the FFLiCharModel structure in heap.
+	 * @param {Module} module - The Emscripten module.
+	 * @param {MaterialConstructor} materialClass - Class for the material (constructor), e.g.: FFLShaderMaterial
+	 * @param {TextureManager} texManager - The {@link TextureManager} instance for this CharModel.
+	 */
+	constructor(ptr: number, module: Module, materialClass: MaterialConstructor, texManager: TextureManager) {
+		this._module = module;
+		this._data = null;
+		this._materialClass = materialClass; // Store the material class.
+		this._materialTextureClass = materialClass;
+		this._textureManager = texManager;
+		this._ptr = ptr;
+		this.__ptr = ptr; // Permanent reference.
+
+		// Unpack the FFLiCharModel structure from heap.
+		const charModelData = this._module.HEAPU8.subarray(ptr, ptr + FFLiCharModel.size);
+
+		this._model = FFLiCharModel.unpack(charModelData);
+		// NOTE: The only property SET in _model is expression.
+		// Everything else is read.
+
+		// Add RenderTargets for faceline and mask.
+		this._facelineTarget = null;
+		this._maskTargets = new Array(FFLExpression.MAX).fill(null);
+		this.expressions = [];
+		this.meshes = new THREE.Group();
+		// Set boundingBox getter ("this" = CharModel), dummy geometry needed
+		// this.meshes.geometry = { }; // NOTE: is this a good idea?
+		// Object.defineProperty(this.meshes.geometry, 'boundingBox',
+		// { get: () => this.boundingBox }); // NOTE: box is too large using this
+
+		this._addCharModelMeshes(module); // Populate this.meshes.
+	}
+
+	// ----------------------- _addCharModelMeshes(module) -----------------------
+	/**
+	 * This is the method that populates meshes
+	 * from the internal FFLiCharModel instance.
+	 * @param {Module} module - Module to pass to drawParamToMesh to access mesh data.
+	 */
+	private _addCharModelMeshes(module: Module): void {
+		console.assert(this.meshes, '_addCharModelMeshes: this.meshes is null or undefined, was this CharModel disposed?');
+
+		/** @type {import('./materials/SampleShaderMaterial').SampleShaderMaterialColorInfo|null} */
+		let colorInfo = null;
+		// Prepare colorInfo from CharModel if it is needed on the mesh's material.
+		if ('colorInfo' in this._materialClass.prototype) {
+			colorInfo = this.getColorInfo();
+		}
+
+		// Add all meshes in the CharModel to the class instance.
+		for (let shapeType = 0; shapeType < FFLiShapeType.MAX; shapeType++) {
+			// Iterate through all DrawParams and convert to THREE.Mesh.
+			const drawParam = this._model.drawParam[shapeType];
+
+			// Skip shape if it's not empty.
+			if (!drawParam.primitiveParam.indexCount) {
+				continue;
+			}
+			const mesh = drawParamToMesh(drawParam, this._materialClass,
+				module, this._textureManager);
+			// Use FFLModulateType to indicate render order.
+			mesh.renderOrder = drawParam.modulateParam.type;
+
+			// Assign colorInfo from the CharModel.
+			if ('colorInfo' in mesh.material) {
+				mesh.material.colorInfo = colorInfo;
+			}
+
+			// Set faceline and mask meshes to use later.
+			switch (shapeType) {
+				case FFLiShapeType.OPA_FACELINE:
+					this._facelineMesh = mesh;
+					break;
+				case FFLiShapeType.XLU_MASK:
+					this._maskMesh = mesh;
+					break;
+			}
+
+			this.meshes.add(mesh); // Add the mesh or null.
+		}
+	}
+
+	// --------------------------- Private Get Methods ---------------------------
+
+	/**
+	 * @returns {number} Pointer to pTextureTempObject.
+	 */
+	private _getTextureTempObjectPtr(): number {
+		return this._model.pTextureTempObject;
+	}
+
+	/**
+	 * @returns {FFLiTextureTempObject} The TextureTempObject containing faceline and mask DrawParams.
+	 */
+	public _getTextureTempObject(): ReturnType<typeof FFLiTextureTempObject.unpack> {
+		const ptr = this._getTextureTempObjectPtr();
+		return FFLiTextureTempObject.unpack(
+			this._module.HEAPU8.subarray(ptr, ptr + FFLiTextureTempObject.size));
+	}
+
+	/**
+	 * Accesses partsTransform in FFLiCharModel,
+	 * converting every FFLVec3 to THREE.Vector3.
+	 * @returns {PartsTransform} PartsTransform using THREE.Vector3 as keys.
+	 */
+	private _getPartsTransform(): ReturnType<typeof FFLPartsTransform.unpack> {
+		const obj: Record<string, FFLVec3> = (this._model.partsTransform);
+		const newPartsTransform: ReturnType<typeof FFLPartsTransform.unpack> = {};
+		for (const key in obj) {
+			const vec = obj[key];
+			// sanity check make sure there is "x"
+			console.assert(vec.x);
+			// convert to THREE.Vector3
+			newPartsTransform[key] = new THREE.Vector3(vec.x, vec.y, vec.z);
+		}
+		return newPartsTransform;
+	}
+
+	/**
+	 * @returns {import('three').Color} The faceline color as THREE.Color.
+	 */
+	private _getFacelineColor(): THREE.Color {
+		// const color = this.additionalInfo.skinColor;
+		// return new THREE.Color(color.r, color.g, color.b);
+		const mod = this._module;
+		const facelineColor = this._model.charInfo.faceColor;
+		/** Allocate return pointer. */
+		const colorPtr = mod._malloc(FFLColor.size);
+		mod._FFLGetFacelineColor(colorPtr, facelineColor);
+		const color = _getFFLColor3(_getFFLColor(colorPtr, mod.HEAPF32));
+		mod._free(colorPtr);
+		return color;
+		// Assume this is in working color space because it is used for clear color.
+	}
+
+	/**
+	 * @returns {import('three').Color} The favorite color as THREE.Color.
+	 */
+	private _getFavoriteColor(): THREE.Color {
+		const mod = this._module;
+		const favoriteColor = this._model.charInfo.favoriteColor;
+		/** Allocate return pointer. */
+		const colorPtr = mod._malloc(FFLColor.size);
+		mod._FFLGetFavoriteColor(colorPtr, favoriteColor); // Get favoriteColor from CharInfo.
+		const color = _getFFLColor3(_getFFLColor(colorPtr, mod.HEAPF32));
+		mod._free(colorPtr);
+		return color;
+	}
+
+	/**
+	 * @returns {Uint8Array} The CharInfo instance.
+	 */
+	private _getCharInfoUint8Array(): Uint8Array {
+		return FFLiCharInfo.pack(this._model.charInfo);
+	}
+
+	/**
+	 * @returns {number} Pointer to pTextureTempObject->maskTextures->partsTextures.
+	 */
+	protected _getPartsTexturesPtr(): number {
+		// eslint-disable-next-line @stylistic/max-len -- indent conflicts with something else
+		return this._model.pTextureTempObject + FFLiTextureTempObject.fields.maskTextures.offset + FFLiMaskTexturesTempObject.fields.partsTextures.offset;
+	}
+
+	/**
+	 * @returns {number} Pointer to pTextureTempObject->facelineTexture.
+	 */
+	public _getFacelineTempObjectPtr(): number {
+		// eslint-disable-next-line @stylistic/max-len -- indent conflicts with something else
+		return this._model.pTextureTempObject + FFLiTextureTempObject.fields.facelineTexture.offset;
+	}
+
+	/**
+	 * @returns {number} Pointer to pTextureTempObject->maskTextures.
+	 */
+	public _getMaskTempObjectPtr(): number {
+		// eslint-disable-next-line @stylistic/max-len -- indent conflicts with something else
+		return this._model.pTextureTempObject + FFLiTextureTempObject.fields.maskTextures.offset;
+	}
+
+	/**
+	 * @returns {number} Pointer to charModelDesc.allExpressionFlag.
+	 */
+	public _getExpressionFlagPtr(): number {
+		// eslint-disable-next-line @stylistic/max-len -- indent conflicts with something else
+		return (this._ptr || 0) + (FFLiCharModel.fields.charModelDesc.offset as number) + (FFLCharModelDesc.fields.allExpressionFlag.offset as number);
+	}
+
+	/**
+	 * Calculates the bounding box from the meshes.
+	 * @returns {import('three').Box3} The bounding box.
+	 */
+	private _getBoundingBox(): THREE.Box3 {
+		// Note: FFL includes three different bounding boxes for each
+		// FFLModelType. This only creates one box per CharModel.
+		const excludeFromBox = [FFLModulateType.SHAPE_MASK, FFLModulateType.SHAPE_GLASS];
+		// Create bounding box selectively excluding mask and glass.
+		const box = new THREE.Box3();
+
+		this.meshes.traverse((child) => {
+			if (!(child instanceof THREE.Mesh) ||
+				// Exclude meshes whose modulateType are in excludeFromBox.
+				excludeFromBox.indexOf(child.geometry.userData.modulateType) !== -1) {
+				return;
+			}
+			// Expand the box.
+			box.expandByObject(child);
+		});
+		return box;
+	}
+
+	/**
+	 * Get the texture resolution.
+	 * @returns {number} The texture resolution.
+	 */
+	public _getResolution(): number {
+		return this._model.charModelDesc.resolution & FFL_RESOLUTION_MASK;
+	}
+
+	/**
+	 * Returns the value for whether the CharModel was created without shapes.
+	 * @returns {boolean} Whether the CharModel was created without shapes.
+	 */
+	public _isTexOnly(): boolean {
+		return (this._model.charModelDesc.modelFlag & FFLModelFlag.NEW_MASK_ONLY) !== 0;
+	}
+
+	// --------------------------------- Disposal ---------------------------------
+
+	/**
+	 * Finalizes the CharModel.
+	 * Frees and deletes the CharModel right after generating textures.
+	 * This is **not** the same as `dispose()` which cleans up the scene.
+	 */
+	public _finalizeCharModel(): void {
+		if (!this._ptr) {
+			return;
+		}
+		this._module._FFLDeleteCharModel(this._ptr);
+		this._module._free(this._ptr);
+		this._ptr = 0;
+	}
+
+	/**
+	 * Disposes RenderTargets for textures created by the CharModel.
+	 */
+	public disposeTargets(): void {
+		// Dispose RenderTargets.
+		if (this._facelineTarget) {
+			console.debug(`Disposing target ${this._facelineTarget.texture.id} for faceline`);
+			this._facelineTarget.dispose();
+			this._facelineTarget = null;
+		}
+		// _maskTargets should always be defined.
+		this._maskTargets.forEach((target, i) => {
+			if (!target) {
+				// No mask for this expression.
+				return;
+			}
+			console.debug(`Disposing target ${target.texture.id} for mask ${i}`);
+			target.dispose();
+			this._maskTargets[i] = null;
+		});
+	}
+
+	// ---------------------- Public Methods - Cleanup, Data ----------------------
+
+	/**
+	 * Disposes the CharModel and removes all associated resources.
+	 * - Disposes materials and geometries.
+	 * - Deletes faceline texture if it exists.
+	 * - Deletes all mask textures.
+	 * - Removes all meshes from the scene.
+	 * @param {boolean} disposeTargets - Whether or not to dispose of mask and faceline render targets.
+	 */
+	public dispose(disposeTargets = true): void {
+		// Print the permanent __ptr rather than _ptr.
+		console.debug('CharModel.dispose: ptr =', this.__ptr);
+		this._finalizeCharModel(); // Should've been called already
+		// Dispose meshes: materials, geometries, textures.
+		if (this.meshes) {
+			// Break these references first (still in meshes)
+			this._facelineMesh = null;
+			this._maskMesh = null;
+			disposeMany(this.meshes);
+			// @ts-expect-error - null not assignable. Always non-null except disposed.
+			this.meshes = null;
+		}
+		// Dispose render textures.
+		if (disposeTargets) {
+			this.disposeTargets();
+		}
+		if (this._textureManager) {
+			this._textureManager.dispose();
+			// Null out reference to TextureManager, assuming
+			// all textures within are already deleted by now.
+			// @ts-expect-error - null not assignable. Always non-null except disposed.
+			this._textureManager = null;
+		}
+	}
+
+	/**
+	 * Serializes the CharModel data to FFLStoreData.
+	 * @returns {Uint8Array} The exported FFLStoreData.
+	 * @throws {Error} Throws if call to _FFLpGetStoreDataFromCharInfo
+	 * returns false, usually when CharInfo verification fails.
+	 */
+	public getStoreData(): Uint8Array {
+		// Serialize the CharInfo.
+		const charInfoData = this._getCharInfoUint8Array();
+
+		const mod = this._module;
+		// Allocate function arguments.
+		/** Input */
+		const charInfoPtr = mod._malloc(FFLiCharInfo.size);
+		/** Output */
+		const storeDataPtr = mod._malloc(FFLStoreData_size);
+		mod.HEAPU8.set(charInfoData, charInfoPtr);
+
+		// Call conversion function.
+		const result = mod._FFLpGetStoreDataFromCharInfo(storeDataPtr, charInfoPtr);
+		// Free and return data.
+		const storeData = mod.HEAPU8.slice(storeDataPtr, storeDataPtr + FFLStoreData_size);
+		mod._free(charInfoPtr);
+		mod._free(storeDataPtr);
+
+		if (!result) {
+			throw new Error('getStoreData: call to FFLpGetStoreDataFromCharInfo returned false, CharInfo verification probably failed');
+		}
+
+		return storeData;
+	}
+
+	// TODO: getStudioCharInfo
+
+	// ------------------------ Mask and Faceline Textures ------------------------
+
+	/**
+	 * Sets the expression for this CharModel and updates the corresponding mask texture.
+	 * @param {FFLExpression} expression - The new expression index.
+	 * @throws {Error} CharModel must have been initialized with the
+	 * expression enabled in the flag and have XLU_MASK in meshes.
+	 */
+	public setExpression(expression: FFLExpression): void {
+		this._model.expression = expression;
+
+		/** or getMaskTexture()? */
+		const targ = this._maskTargets[expression];
+		if (!targ || !targ.texture) {
+			throw new ExpressionNotSet(expression);
+		}
+		if (this._isTexOnly()) {
+			return;
+		}
+		const mesh = this._maskMesh;
+		if (!mesh || !(mesh instanceof THREE.Mesh)) {
+			// So there is no mask mesh, which is not supposed to happen...
+			// ... except for when the expression is 61 or 62, in which case just return.
+			if (expression === FFLExpression.BLANK_61 || expression === FFLExpression.BLANK_62) {
+				return; // Drop out without throwing or setting expression.
+			}
+			throw new Error('setExpression: mask mesh does not exist, cannot set expression on it');
+		}
+		// Update texture and material.
+		(targ.texture as THREE.Texture & { _target: THREE.RenderTarget })._target = targ;
+		(mesh.material as THREE.MeshBasicMaterial).map = targ.texture;
+		(mesh.material as THREE.MeshBasicMaterial).needsUpdate = true;
+	}
+
+	/**
+	 * Gets the faceline texture, or the texture that wraps around
+	 * the faceline shape (opaque, the one hair is placed atop).
+	 * Not to be confused with the texture containing facial features
+	 * such as eyes, mouth, etc. which is the mask.
+	 * The faceline texture may not exist if it is not needed, in which
+	 * case the faceline color is used directly, see property {@link facelineColor}.
+	 * @returns {import('three').RenderTarget|null} The faceline render target, or null if it does not exist,
+	 * in which case {@link facelineColor} should be used. Access .texture on this object to
+	 * get a {@link THREE.Texture} from it. It becomes invalid if the CharModel is disposed.
+	 */
+	public getFaceline(): THREE.RenderTarget | null { // getFaceTexture / "FFLiGetFaceTextureFromCharModel"
+		// Return the render target if it exists.
+		if (this._facelineTarget) {
+			return this._facelineTarget;
+		}
+		return null;
+	}
+
+	/**
+	 * Gets the mask texture, or the texture containing facial
+	 * features such as eyes, mouth, eyebrows, etc. This is wrapped
+	 * around the mask shape, which is a transparent shape
+	 * placed in front of the head model.
+	 * @param {FFLExpression} expression - The desired expression, or the current expression.
+	 * @returns {import('three').RenderTarget|null} The mask render target for the given expression,
+	 * or null if the CharModel was not initialized with that expression.
+	 * Access .texture on this object to get a {@link THREE.Texture} from it.
+	 * It becomes invalid if the CharModel is disposed.
+	 */
+	public getMask(expression = this.expression): THREE.RenderTarget | null { // getMaskTexture
+		// Return the render target if it exists.
+		if (this._maskTargets && this._maskTargets[expression]) {
+			return this._maskTargets[expression];
+		}
+		return null;
+	}
+
+	// ------------------------------ Public Getters ------------------------------
+
+	/**
+	 * The current expression for this CharModel.
+	 * Read-only. Use setExpression to set the expression.
+	 * @returns {FFLExpression} The current expression.
+	 */
+	public get expression(): FFLExpression {
+		return this._model.expression; // mirror
+	}
+
+	/**
+	 * Contains the CharInfo of the model.
+	 * Changes to this will not be reflected whatsoever.
+	 * @returns {FFLiCharInfo} The CharInfo of the model.
+	 */
+	public get charInfo(): void {
+		return this._model.charInfo;
+	}
+
+	/**
+	 * The faceline color for this CharModel.
+	 * @returns {import('three').Color} The faceline color.
+	 */
+	public get facelineColor(): THREE.Color {
+		if (!this._facelineColor) {
+			/** @private */
+			this._facelineColor = this._getFacelineColor();
+		}
+		return this._facelineColor;
+	}
+
+	/**
+	 * The favorite color for this CharModel.
+	 * @returns {import('three').Color} The favorite color.
+	 */
+	public get favoriteColor(): THREE.Color {
+		if (!this._favoriteColor) {
+			this._favoriteColor = this._getFavoriteColor();
+		}
+		return this._favoriteColor;
+	}
+
+	/**
+	 * @returns {number} Gender as 0 = male, 1 = female
+	 */
+	public get gender(): number {
+		return this._model.charInfo.gender;
+	}
+
+	/**
+	 * The parameters in which to transform hats and other accessories.
+	 * @returns {PartsTransform} PartsTransform using THREE.Vector3 as keys.
+	 */
+	public get partsTransform(): ReturnType<typeof FFLPartsTransform.unpack> {
+		if (!this._partsTransform) {
+			// Set partsTransform property as THREE.Vector3.
+			this._partsTransform = this._getPartsTransform();
+		}
+		return this._partsTransform;
+	}
+
+	/**
+	 * @returns {import('three').Box3} The bounding box.
+	 */
+	public get boundingBox(): THREE.Box3 {
+		if (!this._boundingBox) {
+			// Set boundingBox property as THREE.Box3.
+			this._boundingBox = this._getBoundingBox();
+		}
+		return this._boundingBox;
+	}
+
+	/**
+	 * Gets the ColorInfo object needed for SampleShaderMaterial.
+	 * @param {boolean} isSpecial - Determines the pants color, gold if special or gray otherwise.
+	 * @returns {import('./materials/SampleShaderMaterial').SampleShaderMaterialColorInfo}
+	 * The colorInfo object needed by SampleShaderMaterial.
+	 */
+	public getColorInfo(isSpecial = false): SampleShaderMaterialColorInfo {
+		const info = this._model.charInfo;
+		return {
+			facelineColor: info.faceColor,
+			favoriteColor: info.favoriteColor,
+			hairColor: info.hairColor,
+			beardColor: info.beardColor,
+			pantsColor: isSpecial
+				? PantsColor.GoldSpecial
+				: PantsColor.GrayNormal
+		};
+	}
+
+	// -------------------------------- Body Scale --------------------------------
+
+	/**
+	 * Gets a vector in which to scale the body model for this CharModel.
+	 * @returns {import('three').Vector3Like} Scale vector for the body model.
+	 */
+	public getBodyScale(): THREE.Vector3Like {
+		const build = this._model.charInfo.build;
+		const height = this._model.charInfo.height;
+
+		// calculated here in libnn_mii/draw/src/detail/mii_VariableIconBodyImpl.cpp:
+		// void nn::mii::detail::`anonymous namespace'::GetBodyScale(struct nn::util::Float3 *, int, int)
+		// also in Mii Maker USA (0x000500101004A100 v50 ffl_app.rpx): FUN_020737b8
+		const m = 128.0;
+		const x = (build * (height * (0.47 / m) + 0.4)) / m +
+			height * (0.23 / m) + 0.4;
+		const y = (height * (0.77 / m)) + 0.5;
+
+		return { x, y, z: x }; // z is always set to x
+	}
+}

--- a/src/CharModel.ts
+++ b/src/CharModel.ts
@@ -1,15 +1,14 @@
 import * as THREE from 'three';
-import Module from './Module';
-import TextureManager from './TextureManager';
-import { FFLExpression, FFLiShapeType, FFLModelFlag, FFLModulateType } from './enums';
-import { FFL_RESOLUTION_MASK, FFLCharModelDesc, FFLiCharInfo, FFLiCharModel, FFLiMaskTexturesTempObject, FFLiTextureTempObject, FFLStoreData_size, FFLPartsTransform } from './StructFFLiCharModel';
-import { _getFFLColor, _getFFLColor3, drawParamToMesh } from './DrawParam';
-import { FFLVec3 } from '../ffl-original';
-import { FFLColor } from './structs';
-import { disposeMany } from './RenderTargetUtils';
-import { ExpressionNotSet } from './Exceptions';
-import { PantsColor } from './Body';
-import SampleShaderMaterialColorInfo from './materials/SampleShaderMaterialColorInfo';
+import { Module } from '@/Module';
+import TextureManager from '@/TextureManager';
+import { FFLExpression, FFLiShapeType, FFLModelFlag, FFLModulateType } from '@/enums';
+import { FFL_RESOLUTION_MASK, FFLCharModelDesc, FFLiCharInfo, FFLiCharModel, FFLiMaskTexturesTempObject, FFLiTextureTempObject, FFLStoreData_size, FFLPartsTransform } from '@/StructFFLiCharModel';
+import { _getFFLColor, _getFFLColor3, drawParamToMesh } from '@/DrawParam';
+import { FFLColor, FFLVec3 } from '@/structs';
+import { disposeMany } from '@/RenderTargetUtils';
+import { ExpressionNotSet } from '@/Exceptions';
+import { PantsColor } from '@/Body';
+import SampleShaderMaterialColorInfo from '@/materials/SampleShaderMaterialColorInfo';
 
 export type MaterialConstructor = new (...args: any[]) => THREE.Material;
 
@@ -193,7 +192,7 @@ export default class CharModel {
 	 * @returns {PartsTransform} PartsTransform using THREE.Vector3 as keys.
 	 */
 	private _getPartsTransform(): ReturnType<typeof FFLPartsTransform.unpack> {
-		const obj: Record<string, FFLVec3> = (this._model.partsTransform);
+		const obj: Record<string, ReturnType<typeof FFLVec3.unpack>> = (this._model.partsTransform);
 		const newPartsTransform: ReturnType<typeof FFLPartsTransform.unpack> = {};
 		for (const key in obj) {
 			const vec = obj[key];

--- a/src/CharModelCreation.ts
+++ b/src/CharModelCreation.ts
@@ -1,0 +1,218 @@
+// --------- createCharModel(data, modelDesc, materialClass, module) ---------
+
+import { _allocateModelSource, makeExpressionFlag, verifyCharInfo } from "./CharInfo";
+import CharModel, { MaterialConstructor } from "./CharModel";
+import CharModelDescOrExpressionFlag from "./CharModelDescOrExpressionFlag";
+import { _setFaceline, initCharModelTextures } from "./CharModelTextures";
+import { FFLModelFlag, FFLResult } from "./enums";
+import { BrokenInitModel, FFLResultException } from "./Exceptions";
+import Module from "./Module";
+import Renderer from "./renderer";
+import { FFLCharModelDesc, FFLCharModelDescDefault, FFLCharModelSource, FFLiCharInfo, FFLiCharModel } from "./StructFFLiCharModel";
+import TextureManager from "./TextureManager";
+
+/**
+ * Creates a CharModel from data and FFLCharModelDesc.
+ * You must call initCharModelTextures afterwards to finish the process.
+ * Don't forget to call dispose() on the CharModel when you are done.
+ * @param {Uint8Array|FFLiCharInfo} data - Character data. Accepted types:
+ * FFLStoreData, FFLiCharInfo (as Uint8Array and object), StudioCharInfo
+ * @param {CharModelDescOrExpressionFlag} descOrExpFlag - Either a new {@link FFLCharModelDesc},
+ * an array of expressions, a single expression, or an
+ * expression flag (Uint32Array). Default: {@link FFLCharModelDescDefault}
+ * @param {MaterialConstructor} materialClass - Class for the material (constructor). It must be compatible
+ * with FFL, so if your material isn't, try: {@link TextureShaderMaterial}, FFL/LUTShaderMaterial
+ * @param {Module} module - The Emscripten module.
+ * @param {boolean} verify - Whether the CharInfo provided should be verified.
+ * @returns {CharModel} The new CharModel instance.
+ * @throws {FFLResultException|BrokenInitModel|FFLiVerifyReasonException|Error} Throws if `module`, `modelDesc`,
+ * or `data` is invalid, CharInfo verification fails, or CharModel creation fails otherwise.
+ */
+export function createCharModel(data: Uint8Array | ReturnType<typeof FFLiCharInfo.unpack>, descOrExpFlag: CharModelDescOrExpressionFlag, materialClass: MaterialConstructor, module: Module, verify = true): CharModel {
+	// Verify arguments.
+	if (!module || !module._malloc) {
+		throw new Error('createCharModel: module is null or not initialized properly (cannot find ._malloc).');
+	}
+	if (!data) {
+		throw new Error('createCharModel: data is null or undefined.');
+	}
+
+	// Allocate memory for model source, description, char model, and char info.
+	const modelSourcePtr = module._malloc(FFLCharModelSource.size);
+	const modelDescPtr = module._malloc(FFLCharModelDesc.size);
+	const charModelPtr = module._malloc(FFLiCharModel.size);
+
+	// data = getRandomCharInfo(module, FFLGender.FEMALE, FFLAge.ALL, FFLRace.WHITE);
+	// console.debug('getRandomCharInfo result:', FFLiCharInfo.unpack(data));
+	// Get FFLCharModelSource. This converts and allocates CharInfo.
+	const modelSource = _allocateModelSource(data, module);
+	/** Get pBuffer to free it later. */
+	const charInfoPtr = modelSource.pBuffer;
+
+	const modelSourceBuffer = FFLCharModelSource.pack(modelSource);
+	module.HEAPU8.set(modelSourceBuffer, modelSourcePtr);
+
+	const modelDesc = _descOrExpFlagToModelDesc(descOrExpFlag);
+	// Set field to enable new expressions. This field
+	// exists because some callers would leave the other
+	// bits undefined but this does not so no reason to not enable
+	modelDesc.modelFlag |= FFLModelFlag.NEW_EXPRESSIONS;
+
+	const modelDescBuffer = FFLCharModelDesc.pack(modelDesc);
+	module.HEAPU8.set(modelDescBuffer, modelDescPtr);
+
+	/** Local TextureManager instance. */
+	let textureManager;
+	try {
+		// Verify CharInfo before creating.
+		if (verify) {
+			verifyCharInfo(charInfoPtr, module, false); // Don't verify name.
+		}
+
+		// Create TextureManager instance for this CharModel.
+		textureManager = new TextureManager(module, false);
+
+		// Call FFLInitCharModelCPUStep and check the result.
+		// const result = module._FFLInitCharModelCPUStep(charModelPtr, modelSourcePtr, modelDescPtr);
+		const result = module._FFLInitCharModelCPUStepWithCallback(charModelPtr,
+			modelSourcePtr, modelDescPtr, textureManager._textureCallbackPtr);
+		if (result === FFLResult.FILE_INVALID) { // FFL_RESULT_BROKEN
+			throw new BrokenInitModel();
+		}
+		FFLResultException.handleResult(result, 'FFLInitCharModelCPUStep');
+	} catch (error) {
+		if (textureManager) {
+			textureManager.dispose();
+		}
+		// Free CharModel prematurely.
+		module._free(charModelPtr);
+		throw error;
+	} finally {
+		// Free temporary allocations.
+		module._free(modelSourcePtr);
+		module._free(modelDescPtr);
+		module._free(charInfoPtr);
+		// Callback itself is longer read by FFL.
+		if (textureManager) {
+			textureManager.disposeCallback();
+		}
+	}
+
+	// Create the CharModel instance.
+	const charModel = new CharModel(charModelPtr, module, materialClass, textureManager);
+	// The constructor will populate meshes from the FFLiCharModel instance.
+	charModel._data = data; // Store original data passed to function.
+
+	console.debug(`createCharModel: Initialized for "${charModel._model.charInfo.name}", ptr =`, charModelPtr);
+	return charModel;
+}
+
+/**
+ * Converts an expression flag, expression, array of expressions, or object to {@link FFLCharModelDesc}.
+ * Uses the `defaultDesc` as a fallback to return if input is null or applies expression to it.
+ * @param {CharModelDescOrExpressionFlag} [descOrExpFlag] - Either a new {@link FFLCharModelDesc},
+ * an array of expressions, a single expression, or an expression flag (Uint32Array).
+ * @param {FFLCharModelDesc} [defaultDesc] - Fallback if descOrExpFlag is null or expression flag only.
+ * @returns {FFLCharModelDesc} The CharModelDesc with the expression applied, or the default.
+ * @throws {Error} Throws if `descOrExpFlag` is an unexpected type.
+ * @package
+ */
+export function _descOrExpFlagToModelDesc(descOrExpFlag: CharModelDescOrExpressionFlag, defaultDesc = FFLCharModelDescDefault): ReturnType<typeof FFLCharModelDesc.unpack> {
+	if (!descOrExpFlag && typeof descOrExpFlag !== 'number') {
+		return defaultDesc; // Use default if input is falsey.
+	}
+
+	// Convert descOrExpFlag to an expression flag if needed.
+	if (typeof descOrExpFlag === 'number' || Array.isArray(descOrExpFlag)) {
+		// Array of expressions or single expression was passed in.
+		descOrExpFlag = makeExpressionFlag(descOrExpFlag);
+	}
+
+	/** Shallow clone of {@link defaultDesc}. */
+	let newModelDesc = Object.assign({}, defaultDesc);
+
+	// Process descOrExpFlag based on what it is.
+	if (descOrExpFlag instanceof Uint32Array) {
+		// If this is already an expression flag (Uint32Array),
+		// or set to one previously, use it with existing CharModelDesc.
+		newModelDesc.allExpressionFlag = descOrExpFlag;
+	} else if (typeof descOrExpFlag === 'object') {
+		// Assume that descOrExpFlag is a new FFLCharModelDesc.
+		newModelDesc = /** @type {FFLCharModelDesc} */ (descOrExpFlag);
+	} else {
+		throw new Error('_descOrExpFlagToModelDesc: Unexpected type for descOrExpFlag');
+	}
+
+	return newModelDesc;
+}
+
+// ------- updateCharModel(charModel, newData, renderer, descOrExpFlag) -------
+/**
+ * Updates the given CharModel with new data and a new ModelDesc or expression flag.
+ * If `descOrExpFlag` is an array, it is treated as the new expression flag while inheriting the rest
+ * of the ModelDesc from the existing CharModel.
+ * @param {CharModel} charModel - The existing CharModel instance.
+ * @param {Uint8Array|null} newData - The new raw charInfo data, or null to use the original.
+ * @param {Renderer} renderer - The Three.js renderer.
+ * @param {CharModelDescOrExpressionFlag} [descOrExpFlag] - Either a new {@link FFLCharModelDesc},
+ * an array of expressions, a single expression, or an expression flag (Uint32Array).
+ * @param {Object} [options] - Options for updating the model.
+ * @param {boolean} [options.texOnly] - Whether to only update the mask and faceline textures in the CharModel.
+ * @param {boolean} [options.verify] - Whether the CharInfo provided should be verified.
+ * @param {MaterialConstructor|null} [options.materialTextureClass] - The new materialTextureClass to change to.
+ * @returns {CharModel} The updated CharModel instance.
+ * @throws {Error} Unexpected type for descOrExpFlag, newData is null
+ * @todo  TODO: Should `newData` just pass the charInfo object instance instead of "_data"?
+ */
+export function updateCharModel(charModel: CharModel, newData: Uint8Array | null, renderer: Renderer,
+	descOrExpFlag = null, {
+		texOnly = false, verify = true,
+		materialTextureClass = null
+	} = {}) {
+	newData = newData || charModel._data;
+	if (!newData) {
+		throw new Error('updateCharModel: newData is null. It should be retrieved from charModel._data which is set by createCharModel.');
+	}
+
+	/** The new or updated CharModelDesc with the new expression specified. */
+	const newModelDesc = _descOrExpFlagToModelDesc(descOrExpFlag, charModel._model.charModelDesc);
+
+	if (!texOnly) {
+		// Dispose of the old CharModel.
+		charModel.dispose();
+	} else {
+		// Updating textures only. Set respective flag.
+		console.debug(`updateCharModel: Updating ONLY textures for model "${charModel._model.charInfo.name}", ptr =`, charModel._ptr);
+		// NOTE: This flag will only take effect if your FFL is built with -DFFL_ENABLE_NEW_MASK_ONLY_FLAG=ON.
+		newModelDesc.modelFlag |= FFLModelFlag.NEW_MASK_ONLY;
+	}
+
+	// Create a new CharModel with the new data and ModelDesc.
+	const newCharModel = createCharModel(newData, newModelDesc,
+		charModel._materialClass, charModel._module, verify);
+
+	// Initialize its textures unconditionally.
+	initCharModelTextures(newCharModel, renderer,
+		materialTextureClass ? materialTextureClass : charModel._materialTextureClass);
+
+	// Handle textures only case, where new CharModel has textures and old one has shapes.
+	if (texOnly) {
+		charModel.disposeTargets(); // Dispose textures on destination model (will be replaced).
+
+		// Transfer faceline and mask targets.
+		charModel._facelineTarget = newCharModel._facelineTarget;
+		charModel._maskTargets = newCharModel._maskTargets;
+		// Set new CharModel and unset texture only flag.
+		// @ts-expect-error -- _model is supposed to be read-only.
+		charModel._model = newCharModel._model;
+		charModel._model.charModelDesc.modelFlag &= ~FFLModelFlag.NEW_MASK_ONLY;
+		charModel.expressions = newCharModel.expressions;
+		// Apply new faceline and mask to old shapes.
+		newCharModel._facelineTarget && _setFaceline(charModel, newCharModel._facelineTarget);
+		charModel.setExpression(newCharModel.expression);
+
+		return charModel; // Source CharModel has new CharModel's textures.
+	}
+
+	return newCharModel; // Return new or modified CharModel.
+}

--- a/src/CharModelCreation.ts
+++ b/src/CharModelCreation.ts
@@ -1,15 +1,15 @@
 // --------- createCharModel(data, modelDesc, materialClass, module) ---------
 
-import { _allocateModelSource, makeExpressionFlag, verifyCharInfo } from "./CharInfo";
-import CharModel, { MaterialConstructor } from "./CharModel";
-import CharModelDescOrExpressionFlag from "./CharModelDescOrExpressionFlag";
-import { _setFaceline, initCharModelTextures } from "./CharModelTextures";
-import { FFLModelFlag, FFLResult } from "./enums";
-import { BrokenInitModel, FFLResultException } from "./Exceptions";
-import Module from "./Module";
-import Renderer from "./renderer";
-import { FFLCharModelDesc, FFLCharModelDescDefault, FFLCharModelSource, FFLiCharInfo, FFLiCharModel } from "./StructFFLiCharModel";
-import TextureManager from "./TextureManager";
+import { _allocateModelSource, makeExpressionFlag, verifyCharInfo } from "@/CharInfo";
+import CharModel, { MaterialConstructor } from "@/CharModel";
+import CharModelDescOrExpressionFlag from "@/CharModelDescOrExpressionFlag";
+import { _setFaceline, initCharModelTextures } from "@/CharModelTextures";
+import { FFLModelFlag, FFLResult } from "@/enums";
+import { BrokenInitModel, FFLResultException } from "@/Exceptions";
+import { Module } from "@/Module";
+import Renderer from "@/renderer";
+import { FFLCharModelDesc, FFLCharModelDescDefault, FFLCharModelSource, FFLiCharInfo, FFLiCharModel } from "@/StructFFLiCharModel";
+import TextureManager from "@/TextureManager";
 
 /**
  * Creates a CharModel from data and FFLCharModelDesc.
@@ -135,7 +135,7 @@ export function _descOrExpFlagToModelDesc(descOrExpFlag: CharModelDescOrExpressi
 	if (descOrExpFlag instanceof Uint32Array) {
 		// If this is already an expression flag (Uint32Array),
 		// or set to one previously, use it with existing CharModelDesc.
-		newModelDesc.allExpressionFlag = descOrExpFlag;
+		newModelDesc.allExpressionFlag = descOrExpFlag as Uint32Array<ArrayBuffer>;
 	} else if (typeof descOrExpFlag === 'object') {
 		// Assume that descOrExpFlag is a new FFLCharModelDesc.
 		newModelDesc = /** @type {FFLCharModelDesc} */ (descOrExpFlag);

--- a/src/CharModelDescOrExpressionFlag.ts
+++ b/src/CharModelDescOrExpressionFlag.ts
@@ -1,5 +1,5 @@
-import { FFLExpression } from "./enums";
-import { FFLCharModelDesc } from "./StructFFLiCharModel";
+import { FFLExpression } from "@/enums";
+import { FFLCharModelDesc } from "@/StructFFLiCharModel";
 
 type CharModelDescOrExpressionFlag = ReturnType<typeof FFLCharModelDesc.unpack> | FFLExpression[] | FFLExpression | Uint32Array | null;
 

--- a/src/CharModelDescOrExpressionFlag.ts
+++ b/src/CharModelDescOrExpressionFlag.ts
@@ -1,0 +1,6 @@
+import { FFLExpression } from "./enums";
+import { FFLCharModelDesc } from "./StructFFLiCharModel";
+
+type CharModelDescOrExpressionFlag = ReturnType<typeof FFLCharModelDesc.unpack> | FFLExpression[] | FFLExpression | Uint32Array | null;
+
+export default CharModelDescOrExpressionFlag

--- a/src/CharModelTextures.ts
+++ b/src/CharModelTextures.ts
@@ -1,12 +1,12 @@
 import * as THREE from 'three';
-import CharModel, { MaterialConstructor } from "./CharModel";
-import { drawParamToMesh, matSupportsFFL } from "./DrawParam";
-import { _getBGClearMesh, convertModelTexturesToRGBA } from "./ModulateTextureConversion";
-import Renderer from "./renderer";
-import { facelinePartType, FFLiRawMaskDrawParam, FFLiTextureTempObject, maskPartType } from "./StructFFLiCharModel";
-import { _getIdentCamera, createAndRenderToTarget, disposeMany } from './RenderTargetUtils';
-import Module from './Module';
-import { FFLDrawParam } from './structs';
+import CharModel, { MaterialConstructor } from "@/CharModel";
+import { drawParamToMesh, matSupportsFFL } from "@/DrawParam";
+import { _getBGClearMesh, convertModelTexturesToRGBA } from "@/ModulateTextureConversion";
+import Renderer from "@/renderer";
+import { facelinePartType, FFLiRawMaskDrawParam, FFLiTextureTempObject, maskPartType } from "@/StructFFLiCharModel";
+import { _getIdentCamera, createAndRenderToTarget, disposeMany } from '@/RenderTargetUtils';
+import { Module } from '@/Module';
+import { FFLDrawParam } from '@/structs';
 
 // ---------------- initCharModelTextures(charModel, renderer) ----------------
 

--- a/src/CharModelTextures.ts
+++ b/src/CharModelTextures.ts
@@ -1,0 +1,251 @@
+import * as THREE from 'three';
+import CharModel, { MaterialConstructor } from "./CharModel";
+import { drawParamToMesh, matSupportsFFL } from "./DrawParam";
+import { _getBGClearMesh, convertModelTexturesToRGBA } from "./ModulateTextureConversion";
+import Renderer from "./renderer";
+import { facelinePartType, FFLiRawMaskDrawParam, FFLiTextureTempObject, maskPartType } from "./StructFFLiCharModel";
+import { _getIdentCamera, createAndRenderToTarget, disposeMany } from './RenderTargetUtils';
+import Module from './Module';
+import { FFLDrawParam } from './structs';
+
+// ---------------- initCharModelTextures(charModel, renderer) ----------------
+
+/**
+ * Initializes textures (faceline and mask) for a CharModel.
+ * Calls private functions to draw faceline and mask textures.
+ * At the end, calls setExpression to update the mask texture.
+ * Note that this is a separate function due to needing renderer parameter.
+ * @param {CharModel} charModel - The CharModel instance.
+ * @param {Renderer} renderer - The Three.js renderer.
+ * @param {MaterialConstructor} materialClass - The material class (e.g., FFLShaderMaterial).
+ */
+export function initCharModelTextures(charModel: CharModel, renderer: Renderer, materialClass = charModel._materialClass): void {
+	// Check if the passed in renderer is valid by checking the "render" property.
+	console.assert(renderer.render !== undefined,
+		'initCharModelTextures: renderer is an unexpected type (cannot find .render).');
+	const module = charModel._module;
+	// Set material class for render textures.
+	charModel._materialTextureClass = materialClass;
+
+	const textureTempObject = charModel._getTextureTempObject();
+
+	// Use the textureTempObject to set all available expressions on the CharModel.
+	charModel.expressions = textureTempObject.maskTextures.pRawMaskDrawParam
+		// expressions is a list of expression indices, where each index is non-null here.
+		.map((val: number, idx: number) =>
+			// If the value is 0 (null), map it.
+			val !== 0 ? idx : -1)
+		.filter((i: number) => i !== -1); // -1 = null, filter them out.
+
+	// Draw faceline texture if applicable.
+	_drawFacelineTexture(charModel, textureTempObject, renderer, module, materialClass);
+
+	// Warn if renderer.alpha is not set to true.
+	const clearAlpha = renderer.getClearAlpha();
+	(clearAlpha !== 0) && renderer.setClearAlpha(0); // Override clearAlpha to 0.
+
+	// Draw mask textures for all expressions.
+	_drawMaskTextures(charModel, textureTempObject, renderer, module, materialClass);
+	// Finalize CharModel, deleting and freeing it.
+	charModel._finalizeCharModel();
+	// Update the expression to refresh the mask texture.
+	charModel.setExpression(charModel.expression);
+	// Set clearAlpha back.
+	(clearAlpha !== 0) && renderer.setClearAlpha(clearAlpha);
+
+	// convert textures
+	if (!matSupportsFFL(charModel._materialClass)) {
+		if (!matSupportsFFL(charModel._materialTextureClass)) {
+			console.warn('initCharModelTextures: charModel._materialClass does not support modulateMode (no getter), but the _materialTextureClass is either the same or also does not support modulateMode so textures will look wrong');
+		} else {
+			convertModelTexturesToRGBA(charModel, renderer, charModel._materialTextureClass);
+		}
+	}
+}
+
+/**
+ * Draws and applies the faceline texture for the CharModel.
+ * @param {CharModel} charModel - The CharModel.
+ * @param {FFLiTextureTempObject} textureTempObject - The FFLiTextureTempObject containing faceline DrawParams.
+ * @param {Renderer} renderer - The renderer.
+ * @param {Module} module - The Emscripten module.
+ * @param {MaterialConstructor} materialClass - The material class (e.g., FFLShaderMaterial).
+ * @package
+ */
+export function _drawFacelineTexture(charModel: CharModel, textureTempObject: ReturnType<typeof FFLiTextureTempObject.unpack>, renderer: Renderer, module: Module, materialClass: MaterialConstructor): void {
+	// Invalidate faceline texture before drawing (ensures correctness)
+	const facelineTempObjectPtr = charModel._getFacelineTempObjectPtr();
+	module._FFLiInvalidateTempObjectFacelineTexture(facelineTempObjectPtr);
+	// Gather the drawParams that make up the faceline texture.
+	const drawParams = [
+		textureTempObject.facelineTexture[facelinePartType.Make],
+		textureTempObject.facelineTexture[facelinePartType.Line],
+		textureTempObject.facelineTexture[facelinePartType.Beard]
+	].filter(dp => dp && dp.modulateParam.pTexture2D !== 0);
+	// Note that for faceline DrawParams to not be empty,
+	// it must have a texture. For other DrawParams to not
+	// be empty they simply need to have a non-zero index count.
+	if (drawParams.length === 0) {
+		console.debug('_drawFacelineTexture: Skipping faceline texture.');
+		return;
+	}
+
+	// Get the faceline color from CharModel.
+	const bgColor = charModel.facelineColor;
+
+	// Create an offscreen scene.
+	const offscreenScene = new THREE.Scene();
+	offscreenScene.background = bgColor;
+
+	drawParams.forEach(param => offscreenScene.add(
+		drawParamToMesh(param, materialClass, charModel._module, charModel._textureManager)
+	));
+
+	// Determine if the alpha value needs to be 0.
+	if ('needsFacelineAlpha' in materialClass && materialClass.needsFacelineAlpha) {
+		// Three.js does not allow setting an RGB color with alpha value to 0.
+		// Therefore, we need to use a plane with a color and opacity of 0.
+		const mesh = _getBGClearMesh(bgColor);
+		mesh.renderOrder = -1; // Render this before anything else.
+		offscreenScene.add(mesh);
+	}
+
+	// Render scene to texture.
+	const width = charModel._getResolution() / 2;
+	const height = charModel._getResolution();
+	// Configure the RenderTarget for no depth/stencil.
+	const options = {
+		depthBuffer: false,
+		stencilBuffer: false,
+		// Use mirrored repeat wrapping.
+		wrapS: THREE.MirroredRepeatWrapping,
+		wrapT: THREE.MirroredRepeatWrapping
+	};
+
+	const target = createAndRenderToTarget(offscreenScene,
+		_getIdentCamera(), renderer, width, height, options);
+
+	console.debug(`Creating target ${target.texture.id} for faceline`);
+
+	// Apply texture to CharModel.
+	_setFaceline(charModel, target);
+	// Delete temp faceline object to free resources.
+	module._FFLiDeleteTempObjectFacelineTexture(facelineTempObjectPtr,
+		charModel._ptr!, charModel._model.charModelDesc.resourceType);
+	disposeMany(offscreenScene); // Dispose meshes in scene.
+}
+
+/**
+ * Iterates through mask textures and draws each mask texture.
+ * @param {CharModel} charModel - The CharModel.
+ * @param {FFLiTextureTempObject} textureTempObject - The temporary texture object.
+ * @param {Renderer} renderer - The renderer.
+ * @param {Module} module - The Emscripten module.
+ * @param {MaterialConstructor} materialClass - The material class (e.g., FFLShaderMaterial).
+ * @package
+ */
+export function _drawMaskTextures(charModel: CharModel, textureTempObject: ReturnType<typeof FFLiTextureTempObject.unpack>, renderer: Renderer, module: Module, materialClass: MaterialConstructor): void {
+	const maskTempObjectPtr = charModel._getMaskTempObjectPtr();
+	const expressionFlagPtr = charModel._getExpressionFlagPtr();
+
+	// Collect all scenes and only dispose them at the end.
+	/** @type {Array<import('three').Scene>} */
+	const scenes = [];
+
+	// Iterate through pMaskRenderTextures to find out which masks are needed.
+	for (let i = 0; i < charModel._model.pMaskRenderTextures.length; i++) {
+		// pRenderTexture will be set to 1 if mask is meant to be drawn there.
+		if (charModel._model.pMaskRenderTextures[i] === 0) {
+			continue;
+		}
+		const rawMaskDrawParamPtr = textureTempObject.maskTextures.pRawMaskDrawParam[i];
+		const rawMaskDrawParam = FFLiRawMaskDrawParam.unpack(
+			module.HEAPU8.subarray(rawMaskDrawParamPtr,
+				rawMaskDrawParamPtr + FFLiRawMaskDrawParam.size));
+		module._FFLiInvalidateRawMask(rawMaskDrawParamPtr);
+
+		const { target, scene } = _drawMaskTexture(charModel,
+			rawMaskDrawParam, renderer, materialClass);
+		console.debug(`Creating target ${target.texture.id} for mask ${i}`);
+		charModel._maskTargets[i] = target;
+
+		scenes.push(scene);
+	}
+
+	// Some texures are shared which is why this
+	// needs to be done given that disposeMeshes
+	// unconditionally deletes textures.
+	scenes.forEach((scene) => {
+		disposeMany(scene);
+	});
+
+	module._FFLiDeleteTempObjectMaskTextures(maskTempObjectPtr,
+		expressionFlagPtr, charModel._model.charModelDesc.resourceType);
+	module._FFLiDeleteTextureTempObject(charModel._ptr!);
+}
+
+/**
+ * Draws a single mask texture based on a RawMaskDrawParam.
+ * Note that the caller needs to dispose meshes within the returned scene.
+ * @param {CharModel} charModel - The CharModel.
+ * @param {Array<FFLDrawParam>} rawMaskParam - The RawMaskDrawParam.
+ * @param {Renderer} renderer - The renderer.
+ * @param {MaterialConstructor} materialClass - The material class (e.g., FFLShaderMaterial).
+ * @returns {{target: import('three').RenderTarget, scene: import('three').Scene}}
+ * The RenderTarget and scene of this mask texture.
+ * @package
+ */
+export function _drawMaskTexture(charModel: CharModel, rawMaskParam: ReturnType<typeof FFLDrawParam.unpack>[], renderer: Renderer, materialClass: MaterialConstructor): { target: THREE.RenderTarget; scene: THREE.Scene } {
+	const drawParams = [
+		rawMaskParam[maskPartType.MustacheR],
+		rawMaskParam[maskPartType.MustacheL],
+		rawMaskParam[maskPartType.Mouth],
+		rawMaskParam[maskPartType.EyebrowR],
+		rawMaskParam[maskPartType.EyebrowL],
+		rawMaskParam[maskPartType.EyeR],
+		rawMaskParam[maskPartType.EyeL],
+		rawMaskParam[maskPartType.Mole]
+	].filter(dp => dp && dp.primitiveParam.indexCount !== 0);
+	console.assert(drawParams.length, '_drawMaskTexture: All DrawParams are empty.');
+	// Configure the RenderTarget for no depth/stencil.
+	const options = {
+		depthBuffer: false,
+		stencilBuffer: false
+	};
+	// Create an offscreen transparent scene for 2D mask rendering.
+	const offscreenScene = new THREE.Scene();
+	offscreenScene.background = null;
+	drawParams.forEach(param => offscreenScene.add(
+		drawParamToMesh(param, materialClass, charModel._module, charModel._textureManager)
+	));
+	const width = charModel._getResolution();
+
+	const target = createAndRenderToTarget(offscreenScene,
+		_getIdentCamera(), renderer, width, width, options);
+
+	return { target, scene: offscreenScene };
+	// Caller needs to dispose meshes in scene.
+}
+
+/**
+ * Sets the faceline texture of the given CharModel from the RenderTarget.
+ * @param {CharModel} charModel - The CharModel instance.
+ * @param {import('three').RenderTarget} target - RenderTarget for the faceline texture.
+ * @throws {Error} CharModel must be initialized with OPA_FACELINE in meshes.
+ * @package
+ */
+export function _setFaceline(charModel: CharModel, target: THREE.RenderTarget): void {
+	console.assert(target && target.texture, 'setFaceline: passed in RenderTarget is invalid');
+	charModel._facelineTarget = target; // Store for later disposal.
+	if (charModel._isTexOnly()) {
+		return;
+	}
+	const mesh = charModel._facelineMesh;
+	if (!mesh || !(mesh instanceof THREE.Mesh)) {
+		throw new Error('setFaceline: faceline shape does not exist');
+	}
+	// Update texture and material.
+	(target.texture as THREE.Texture & { _target: THREE.RenderTarget })._target = target;
+	(mesh.material as THREE.MeshBasicMaterial).map = target.texture;
+	(mesh.material as THREE.MeshBasicMaterial).needsUpdate = true;
+}

--- a/src/CodecUtilities.ts
+++ b/src/CodecUtilities.ts
@@ -1,0 +1,80 @@
+/**
+ * Removes all spaces from a string.
+ * @param {string} str - The input string.
+ * @returns {string} The string without spaces.
+ */
+export function stripSpaces(str: string) {
+	return str.replace(/\s+/g, '');
+}
+
+/**
+ * Converts a hexadecimal string to a Uint8Array.
+ * @param {string} hex - The hexadecimal string.
+ * @returns {Uint8Array} The converted Uint8Array.
+ */
+export function hexToUint8Array(hex: string) {
+	const match = hex.match(/.{1,2}/g);
+	// If match returned null, use an empty array.
+	const arr = (match ? match : []).map(function (byte) {
+		return parseInt(byte, 16);
+	});
+	return new Uint8Array(arr);
+}
+
+/**
+ * Converts a Base64 or Base64-URL encoded string to a Uint8Array.
+ * @param {string} base64 - The Base64-encoded string.
+ * @returns {Uint8Array} The converted Uint8Array.
+ */
+export function base64ToUint8Array(base64: string) {
+	// Replace URL-safe Base64 characters
+	const normalizedBase64 = base64.replace(/-/g, '+').replace(/_/g, '/');
+	// Custom function to pad the string with '=' manually
+	/**
+	 * @param {string} str - The Base64 string to pad.
+	 * @returns {string} The padded Base64 string.
+	 */
+	function padBase64(str: string) {
+		while (str.length % 4 !== 0) {
+			str += '=';
+		}
+		return str;
+	}
+	// Add padding if necessary.
+	const paddedBase64 = padBase64(normalizedBase64);
+	const binaryString = atob(paddedBase64);
+	const len = binaryString.length;
+	const bytes = new Uint8Array(len);
+	for (let i = 0; i < len; i++) {
+		bytes[i] = binaryString.charCodeAt(i);
+	}
+	return bytes;
+}
+
+/**
+ * Converts a Uint8Array to a Base64 string.
+ * @param {Array<number>} data - The Uint8Array to convert.
+ * @returns {string} The Base64-encoded string.
+ */
+export function uint8ArrayToBase64(data: number[]) {
+	return btoa(String.fromCharCode.apply(null, data));
+}
+
+/**
+ * Parses a string contaning either hex or Base64 representation
+ * of bytes into a Uint8Array, stripping spaces.
+ * @param {string} text - The input string, which can be either hex or Base64.
+ * @returns {Uint8Array} The parsed Uint8Array.
+ */
+export function parseHexOrB64ToUint8Array(text: string) {
+	let inputData;
+	// Decode it to a Uint8Array whether it's hex or Base64
+	const textData = stripSpaces(text);
+	// Check if it's base 16 exclusively, otherwise assume Base64
+	if (/^[0-9a-fA-F]+$/.test(textData)) {
+		inputData = hexToUint8Array(textData);
+	} else {
+		inputData = base64ToUint8Array(textData);
+	}
+	return inputData;
+}

--- a/src/DrawParam.ts
+++ b/src/DrawParam.ts
@@ -1,10 +1,10 @@
 import * as THREE from 'three';
-import { FFLAttributeBufferType, FFLCullMode, FFLModulateMode, FFLModulateType } from './enums';
-import { MaterialConstructor } from './CharModel';
-import Module from './Module';
-import TextureManager from './TextureManager';
-import { FFLDrawParam, FFLColor, FFLModulateParam } from './structs';
-import FFLShaderMaterialParameters from './materials/FFLShaderMaterialParameters';
+import { FFLAttributeBufferType, FFLCullMode, FFLModulateMode, FFLModulateType } from '@/enums';
+import { MaterialConstructor } from '@/CharModel';
+import { Module } from '@/Module';
+import TextureManager from '@/TextureManager';
+import { FFLDrawParam, FFLColor, FFLModulateParam } from '@/structs';
+import FFLShaderMaterialParameters from '@/materials/FFLShaderMaterialParameters';
 
 /**
  * @param {Function} material - Class constructor for the material to test.

--- a/src/DrawParam.ts
+++ b/src/DrawParam.ts
@@ -1,0 +1,455 @@
+import * as THREE from 'three';
+import { FFLAttributeBufferType, FFLCullMode, FFLModulateMode, FFLModulateType } from './enums';
+import { MaterialConstructor } from './CharModel';
+import Module from './Module';
+import TextureManager from './TextureManager';
+import { FFLDrawParam, FFLColor, FFLModulateParam } from './structs';
+import FFLShaderMaterialParameters from './materials/FFLShaderMaterialParameters';
+
+/**
+ * @param {Function} material - Class constructor for the material to test.
+ * @returns {boolean} Whether or not the material class supports FFL swizzled (modulateMode) textures.
+ */
+export function matSupportsFFL(material: Function): boolean {
+	return ('modulateMode' in material.prototype);
+}
+
+// ------ drawParamToMesh(drawParam, materialClass, module, texManager) ------
+/**
+ * Converts FFLDrawParam into a THREE.Mesh.
+ * Binds geometry, texture, and material parameters.
+ * @param {FFLDrawParam} drawParam - The DrawParam representing the mesh.
+ * @param {MaterialConstructor} materialClass - Class for the material (constructor).
+ * @param {Module} module - The Emscripten module.
+ * @param {TextureManager} texManager - The {@link TextureManager} instance
+ * for which to look for textures referenced by the DrawParam.
+ * @returns {import('three').Mesh} The THREE.Mesh instance.
+ * @package
+ */
+export function drawParamToMesh(drawParam: ReturnType<typeof FFLDrawParam.unpack>, materialClass: MaterialConstructor, module: Module, texManager: TextureManager): THREE.Mesh {
+	console.assert(drawParam, 'drawParamToMesh: drawParam may be null.');
+	console.assert(texManager, 'drawParamToMesh: Passed in TextureManager is null or undefined, is it constructed?');
+	console.assert(typeof materialClass === 'function', 'drawParamToMesh: materialClass is unexpectedly not a function.');
+
+	// Skip if the index count is 0, indicating no shape data.
+	console.assert(drawParam.primitiveParam.indexCount, 'drawParamToMesh: Index count is 0, indicating shape is empty. Check that before it gets passed into this function.');
+
+	// Bind geometry data.
+	const geometry = _bindDrawParamGeometry(drawParam, module);
+
+	// HACK: Allow the material class to modify the geometry if it needs to.
+	if ('modifyBufferGeometry' in materialClass && // Static function
+		typeof materialClass.modifyBufferGeometry === 'function') {
+		materialClass.modifyBufferGeometry(drawParam, geometry);
+	}
+
+	// Determine cull mode by mapping FFLCullMode to THREE.Side.
+	const cullModeToThreeSide: Partial<Record<FFLCullMode, THREE.Side>> = {
+		[FFLCullMode.NONE]: THREE.DoubleSide,
+		[FFLCullMode.BACK]: THREE.FrontSide,
+		[FFLCullMode.FRONT]: THREE.BackSide,
+		// Used by faceline/mask 2D planes for some reason:
+		[FFLCullMode.MAX]: THREE.DoubleSide
+	};
+	const side = cullModeToThreeSide[drawParam.cullMode as FFLCullMode];
+	console.assert(side !== undefined, `drawParamToMesh: Unexpected value for FFLCullMode: ${drawParam.cullMode}`);
+	// Get texture.
+	const texture = _getTextureFromModulateParam(drawParam.modulateParam, texManager);
+
+	// Apply modulateParam material parameters.
+	const isFFLMaterial = matSupportsFFL(materialClass);
+	const params = _applyModulateParam(drawParam.modulateParam, module, isFFLMaterial);
+	// Create object for material parameters.
+	const materialParam = {
+		side: side,
+		// Apply texture.
+		map: texture,
+		...params
+	};
+
+	// Special case for if tangent (NEEDED for aniso) is missing, and...
+	if (geometry.attributes.tangent === undefined && // "_color" can be tested too.
+		// ... material is FFLShaderMaterial. Which is the only one using that attribute.
+		'useSpecularModeBlinn' in materialClass.prototype) {
+		(materialParam as FFLShaderMaterialParameters).useSpecularModeBlinn = true;
+	}
+
+	// Create material using the provided materialClass.
+	const material = new materialClass(materialParam);
+	// Create mesh and set userData.modulateType.
+	const mesh = new THREE.Mesh(geometry, material);
+
+	// Apply pAdjustMatrix transformations if it is not null.
+	if (drawParam.primitiveParam.pAdjustMatrix !== 0) {
+		_applyAdjustMatrixToMesh(drawParam.primitiveParam.pAdjustMatrix, mesh, module.HEAPF32);
+	}
+
+	// Set properties that can be used to reconstruct the material in userData.
+	// NOTE: These are only in geometry (primitive) because FFL-Testing does the same, see:
+	// https://github.com/ariankordi/FFL-Testing/blob/2219f64473ac8312bab539cd05c00f88c14d2ffd/src/GLTFExportCallback.cpp#L828
+	if (mesh.geometry.userData) {
+		// Set modulateMode/modulateType (not modulateColor or cullMode).
+		mesh.geometry.userData.modulateMode = drawParam.modulateParam.mode;
+		mesh.geometry.userData.modulateType = drawParam.modulateParam.type;
+		// Note that color is a part of THREE.Material and will most always be there
+		mesh.geometry.userData.modulateColor = params.color instanceof THREE.Color
+			? [params.color.r, params.color.g, params.color.b, 1.0]
+			: [1.0, 1.0, 1.0, 1.0];
+		mesh.geometry.userData.cullMode = drawParam.cullMode;
+	}
+	return mesh;
+}
+
+/**
+ * Binds geometry attributes from drawParam into a THREE.BufferGeometry.
+ * @param {FFLDrawParam} drawParam - The DrawParam representing the mesh.
+ * @param {Module} module - The Emscripten module from which to read the heap.
+ * @returns {import('three').BufferGeometry} The geometry.
+ * @package
+ * @todo Does not yet handle color stride = 0
+ */
+export function _bindDrawParamGeometry(drawParam: ReturnType<typeof FFLDrawParam.unpack>, module: Module): THREE.BufferGeometry {
+	/**
+	 * @param {string} typeStr - The type of the attribute.
+	 * @param {number} stride - The stride to display.
+	 * @returns {void}
+	 */
+	const unexpectedStride = (typeStr: string, stride: number): void =>
+		console.assert(false, `_bindDrawParamGeometry: Unexpected stride for attribute ${typeStr}: ${stride}`);
+
+	// Access FFLAttributeBufferParam.
+	const attributes = drawParam.attributeBuffers;
+	const positionBuffer = attributes[FFLAttributeBufferType.POSITION];
+	// There should always be positions.
+	console.assert(positionBuffer.size, '_bindDrawParamGeometry: Position buffer must not have size of 0');
+
+	// Get vertex count from position buffer.
+	const vertexCount = positionBuffer.size / positionBuffer.stride;
+	/** Create BufferGeometry. */
+	const geometry = new THREE.BufferGeometry();
+	// Bind index data.
+	const indexPtr = drawParam.primitiveParam.pIndexBuffer / 2;
+	const indexCount = drawParam.primitiveParam.indexCount;
+	const indices = module.HEAPU16.slice(indexPtr, indexPtr + indexCount);
+	geometry.setIndex(new THREE.Uint16BufferAttribute(indices, 1));
+	// Add attribute data.
+	for (const typeStr in attributes) {
+		const buffer = attributes[typeStr];
+		const type = parseInt(typeStr);
+		// Skip disabled attributes that have size of 0.
+		if (buffer.size === 0) {
+			continue;
+		}
+
+		switch (type) {
+			case FFLAttributeBufferType.POSITION: {
+				if (buffer.stride === 16) {
+					// 3 floats, last 4 bytes unused.
+					/** float data type */
+					const ptr = buffer.ptr / 4;
+					const data = module.HEAPF32.slice(ptr, ptr + (vertexCount * 4));
+					const interleavedBuffer = new THREE.InterleavedBuffer(data, 4);
+					// Only works on Three.js r109 and above (previously used addAttribute which can be remapped)
+					geometry.setAttribute('position', new THREE.InterleavedBufferAttribute(interleavedBuffer, 3, 0));
+					// ^^ Selectively use first three elements only.
+				} else if (buffer.stride === 6) {
+					/** half-float data type */
+					const ptr = buffer.ptr / 2;
+					const data = module.HEAPU16.slice(ptr, ptr + (vertexCount * 3));
+					geometry.setAttribute('position', new THREE.Float16BufferAttribute(data, 3));
+				} else {
+					unexpectedStride(typeStr, buffer.stride);
+				}
+				break;
+			}
+			case FFLAttributeBufferType.NORMAL: {
+				// Either int8 or 10_10_10_2
+				// const data = module.HEAP32.slice(buffer.ptr / 4, buffer.ptr / 4 + vertexCount);
+				// const buf = gl.createBuffer();
+				// gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+				// gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
+				// // Bind vertex type GL_INT_2_10_10_10_REV/ / 0x8D9F.
+				// geometry.setAttribute('normal', new THREE.GLBufferAttribute(buf, 0x8D9F, 4, 4));
+				const data = module.HEAP8.slice(buffer.ptr, buffer.ptr + buffer.size);
+				geometry.setAttribute('normal', new THREE.Int8BufferAttribute(data, buffer.stride, true));
+				break;
+			}
+			case FFLAttributeBufferType.TANGENT: {
+				// Int8
+				const data = module.HEAP8.slice(buffer.ptr, buffer.ptr + buffer.size);
+				geometry.setAttribute('tangent', new THREE.Int8BufferAttribute(data, buffer.stride, true));
+				break;
+			}
+			case FFLAttributeBufferType.TEXCOORD: {
+				if (buffer.stride === 8) {
+					/** float data type */
+					const ptr = buffer.ptr / 4;
+					const data = module.HEAPF32.slice(ptr, ptr + (vertexCount * 2));
+					geometry.setAttribute('uv', new THREE.Float32BufferAttribute(data, 2));
+				} else if (buffer.stride === 4) {
+					/** half-float data type */
+					const ptr = buffer.ptr / 2;
+					const data = module.HEAPU16.slice(ptr, ptr + (vertexCount * 2));
+					geometry.setAttribute('uv', new THREE.Float16BufferAttribute(data, 2));
+				} else {
+					unexpectedStride(typeStr, buffer.stride);
+				}
+				break;
+			}
+			case FFLAttributeBufferType.COLOR: {
+				// Uint8
+
+				// Use default value if it does not exist.
+				// NOTE: Does not handle values for u_color other
+				// than the default 0/0/0/1 (custom u_parameter_mode)
+				if (buffer.stride === 0) {
+					break;
+				}
+				// Use "_color" because NOTE this is what the FFL-Testing exports and existing shaders do
+				const data = module.HEAPU8.slice(buffer.ptr, buffer.ptr + buffer.size);
+				geometry.setAttribute('_color', new THREE.Uint8BufferAttribute(data, buffer.stride, true));
+				break;
+			}
+		}
+	}
+	return geometry;
+}
+
+/**
+ * Retrieves a texture from ModulateParam.
+ * Does not assign texture for faceline or mask types.
+ * @param {FFLModulateParam} modulateParam - drawParam.modulateParam.
+ * @param {TextureManager} textureManager - The {@link TextureManager} instance
+ * for which to look for the texture referenced.
+ * @returns {import('three').Texture|null} The texture if found.
+ * @package
+ */
+export function _getTextureFromModulateParam(modulateParam: ReturnType<typeof FFLModulateParam.unpack>, textureManager: TextureManager): THREE.Texture | null {
+	// Only assign texture if pTexture2D is not null.
+	if (!modulateParam.pTexture2D ||
+		// The pointer will be set to just "1" for
+		// faceline and mask textures that are supposed
+		// to be targets (FFL_TEXTURE_PLACEHOLDER, FFLI_RENDER_TEXTURE_PLACEHOLDER)
+		modulateParam.pTexture2D === 1) {
+		return null; // No texture to bind.
+	}
+	const texturePtr = modulateParam.pTexture2D;
+	const texture: THREE.Texture | null | undefined = textureManager.get(texturePtr);
+	console.assert(texture, `_getTextureFromModulateParam: Texture not found for ${texturePtr}.`);
+	// Selective apply mirrored repeat (not supported on NPOT/mipmap textures for WebGL 1.0)
+	const applyMirrorTypes = [
+		FFLModulateType.SHAPE_FACELINE, FFLModulateType.SHAPE_CAP, FFLModulateType.SHAPE_GLASS];
+	// ^^ Faceline, cap, and glass. NOTE that faceline texture won't go through here
+	if (applyMirrorTypes.indexOf(modulateParam.type) !== -1) {
+		texture!.wrapS = THREE.MirroredRepeatWrapping;
+		texture!.wrapT = THREE.MirroredRepeatWrapping;
+		texture!.needsUpdate = true;
+	}
+	return texture!;
+}
+
+/**
+ * Retrieves blending parameters based on the FFLModulateType.
+ * Will only actually return anything for mask and faceline shapes.
+ * @param {FFLModulateType} modulateType - The modulate type.
+ * @param {FFLModulateMode} [modulateMode] - The modulate mode, used to
+ * differentiate body/pants modulate types from mask modulate types.
+ * @returns {Object} An object containing blending parameters for the Three.js material constructor, or an empty object.
+ * @throws {Error} Unknown modulate type
+ * @package
+ */
+export function _getBlendOptionsFromModulateType(modulateType: FFLModulateType, modulateMode: FFLModulateMode):
+	| {}
+	| { blending: number; blendSrc: number; blendSrcAlpha: number; blendDst: number; }
+	| { blending: number; blendSrc: number; blendSrcAlpha: number; blendDst: number; blendDstAlpha: number; }
+{
+	/*
+	if (modulateType >= FFLModulateType.SHAPE_FACELINE &&
+		modulateType <= FFLModulateType.SHAPE_CAP) {
+		// Opaque (DrawOpa)
+		// glTF alphaMode: OPAQUE
+		return {
+			blending: THREE.CustomBlending,
+			blendSrcAlpha: THREE.SrcAlphaFactor,
+			blendDstAlpha: THREE.OneFactor
+		};
+	} else if (modulateType >= FFLModulateType.SHAPE_MASK &&
+		modulateType <= FFLModulateType.SHAPE_GLASS) {
+		// Translucent (DrawXlu)
+		// glTF alphaMode: MASK (TEXTURE_DIRECT), or BLEND (LUMINANCE_ALPHA)?
+		return {
+			blending: THREE.CustomBlending,
+			blendSrc: THREE.SrcAlphaFactor,
+			blendDst: THREE.OneMinusSrcAlphaFactor,
+			blendDstAlpha: THREE.OneFactor,
+			// transparent: true
+			depthWrite: false // kept on inside of LUTShaderMaterial
+		};
+	} else
+	*/
+	if (modulateMode !== 0 && modulateType >= FFLModulateType.SHAPE_MAX &&
+		modulateType <= FFLModulateType.MOLE) {
+		// Mask Textures
+		return {
+			blending: THREE.CustomBlending,
+			blendSrc: THREE.OneMinusDstAlphaFactor,
+			blendSrcAlpha: THREE.SrcAlphaFactor,
+			blendDst: THREE.DstAlphaFactor
+		};
+	} else if (modulateMode !== 0 && modulateType >= FFLModulateType.FACE_MAKE &&
+		modulateType <= FFLModulateType.FILL) {
+		// Faceline Texture
+		return {
+			blending: THREE.CustomBlending,
+			blendSrc: THREE.SrcAlphaFactor,
+			blendDst: THREE.OneMinusSrcAlphaFactor,
+			blendSrcAlpha: THREE.OneFactor,
+			blendDstAlpha: THREE.OneFactor
+		};
+	}
+	return {};
+	// No blending options needed.
+	// else {
+	// 	throw new Error(`_getBlendOptionsFromModulateType: Unknown modulate type: ${modulateType}`);
+	// }
+}
+
+/* eslint-disable jsdoc/require-returns-type -- Allow TS to predict return type. */
+/**
+ * Returns an object of parameters for a Three.js material constructor, based on {@link FFLModulateParam}.
+ * @param {FFLModulateParam} modulateParam - Property `modulateParam` of {@link FFLDrawParam}.
+ * @param {Module} module - The Emscripten module for accessing color pointers in heap.
+ * @param {boolean} [forFFLMaterial] - Whether or not to include modulateMode/Type parameters for material parameters.
+ * @returns Parameters for creating a Three.js material.
+ * @package
+ */
+export function _applyModulateParam(modulateParam: ReturnType<typeof FFLModulateParam.unpack>, module: Module, forFFLMaterial = true): Record<string, any> {
+	/* eslint-enable jsdoc/require-returns-type -- Allow TS to predict return type. */
+	// Apply constant colors.
+	/** @type {import('three').Color|Array<import('three').Color>|null} */
+	let color = null;
+
+	/**
+	 * Single constant color.
+	 * @type {FFLColor|null}
+	 */
+	let color4 = null;
+	const f32 = module.HEAPF32;
+	// If both pColorG and pColorB are provided, combine them into an array.
+	if (modulateParam.pColorG !== 0 && modulateParam.pColorB !== 0) {
+		color = [
+			_getFFLColor3(_getFFLColor(modulateParam.pColorR, f32)),
+			_getFFLColor3(_getFFLColor(modulateParam.pColorG, f32)),
+			_getFFLColor3(_getFFLColor(modulateParam.pColorB, f32))
+		];
+	} else if (modulateParam.pColorR !== 0) {
+		// Otherwise, set it as a single color.
+		color4 = _getFFLColor(modulateParam.pColorR, f32);
+		color = _getFFLColor3(color4);
+	}
+
+	// Use opacity from single pColorR (it's only 0 for "fill" 2D plane)
+	const opacity = color4 ? color4.a : 1.0;
+	// Otherwise use 1.0, which is the opacity used pretty much everywhere.
+
+	// Set transparent property for Xlu/mask and higher.
+	const transparent = modulateParam.type >= FFLModulateType.SHAPE_MASK;
+
+	// Disable lighting if this is a 2D plane (mask/faceline) and not opaque (body/pants).
+	const lightEnable = !(modulateParam.type >= FFLModulateType.SHAPE_MAX &&
+		modulateParam.mode !== FFLModulateMode.CONSTANT);
+
+	/** Do not include the parameters if forFFLMaterial is false. */
+	const modulateModeType = forFFLMaterial
+		? {
+			modulateMode: modulateParam.mode,
+			modulateType: modulateParam.type // need this set before color.
+		}
+		: {};
+
+	// Not applying map here, that happens in _getTextureFromModulateParam.
+	const param = Object.assign(modulateModeType, {
+		// Common Three.js material parameters.
+		color: color,
+		opacity: opacity,
+		transparent: transparent,
+		// Depth writing is disabled for DrawXlu stage however
+		// it is kept enabled in LUTShaderMaterial because its
+		// alpha testing chooses to not write depth. Since we are
+		// disabling it anyway, that means shapes NEED to be in order
+		depthWrite: !transparent,
+
+		// Apply blending options (for mask/faceline) based on modulateType.
+		..._getBlendOptionsFromModulateType(modulateParam.type, modulateParam.mode)
+	});
+
+	// only for mask/faceline which should not be drawn in non-ffl materials:
+	if (!lightEnable) {
+		// Only set lightEnable if it is not default.
+		(param as Record<string, any>).lightEnable = lightEnable;
+	}
+	return param;
+}
+
+/**
+ * Dereferences a pointer to FFLColor.
+ * @param {number} colorPtr - The pointer to the color.
+ * @param {Float32Array} heapf32 - HEAPF32 buffer view within {@link Module}.
+ * @returns {FFLColor} The converted Vector4.
+ */
+export function _getFFLColor(colorPtr: number, heapf32: Float32Array): { r: number; g: number; b: number; a: number; } {
+	console.assert(colorPtr, '_getFFLColor: Received null pointer');
+	// Assign directly from HEAPF32.
+	const colorData = heapf32.subarray(colorPtr / 4, colorPtr / 4 + 4);
+	return { r: colorData[0], g: colorData[1], b: colorData[2], a: colorData[3] };
+}
+
+/**
+ * Creates a THREE.Color from {@link FFLColor}.
+ * @param {FFLColor} color - The {@link FFLColor} object..
+ * @returns {import('three').Color} The converted color.
+ */
+export function _getFFLColor3(color: ReturnType<typeof FFLColor.unpack>): THREE.Color {
+	return new THREE.Color(color.r, color.g, color.b);
+}
+
+/**
+ * Applies transformations in pAdjustMatrix within a {@link FFLDrawParam} to a mesh.
+ * @param {number} pMtx - Pointer to rio::Matrix34f.
+ * @param {import('three').Object3D} mesh - The mesh to apply transformations to.
+ * @param {Float32Array} heapf32 - HEAPF32 buffer view within {@link Module}.
+ * @package
+ */
+export function _applyAdjustMatrixToMesh(pMtx: number, mesh: THREE.Object3D, heapf32: Float32Array): void {
+	// Assumes pMtx !== 0.
+	const ptr = pMtx / 4;
+	/** sizeof(rio::BaseMtx34f<float>) */
+	const m = heapf32.slice(ptr, ptr + (0x30 / 4));
+	// console.debug('drawParamToMesh: shape has pAdjustMatrix: ', m);
+	/**
+	 * Creates a THREE.Matrix4 from a 3x4 row-major matrix array.
+	 * @param {Array<number>|Float32Array} m - The array that makes up the 3x4 matrix, expected to have 12 elements.
+	 * @returns {import('three').Matrix4} The converted matrix.
+	 */
+	function matrixFromRowMajor3x4(m: number[] | Float32Array) {
+		const matrix = new THREE.Matrix4();
+		// Convert from rio::BaseMtx34f/row-major to column-major.
+		matrix.set(
+			m[0], m[4], m[8], m[3],
+			m[1], m[5], m[9], m[7],
+			m[2], m[6], m[10], m[11],
+			0, 0, 0, 1
+		);
+		return matrix;
+	}
+	// Create a matrix from the array.
+	const matrix = matrixFromRowMajor3x4(m);
+
+	// Set position and scale. FFLiAdjustShape does not set rotation.
+	mesh.scale.setFromMatrixScale(matrix);
+	mesh.position.setFromMatrixPosition(matrix);
+	// Account for flipped X scale (setFromMatrixScale doesn't?)
+	if (matrix.elements[0] === -1) {
+		mesh.scale.x = -1;
+	}
+}

--- a/src/Exceptions.ts
+++ b/src/Exceptions.ts
@@ -1,4 +1,4 @@
-import { FFLExpression, FFLResult } from "./enums";
+import { FFLExpression, FFLResult } from "@/enums";
 
 /**
  * Base exception type for all exceptions based on FFLResult.

--- a/src/Exceptions.ts
+++ b/src/Exceptions.ts
@@ -1,0 +1,147 @@
+import { FFLExpression, FFLResult } from "./enums";
+
+/**
+ * Base exception type for all exceptions based on FFLResult.
+ * https://github.com/ariankordi/FFLSharp/blob/master/FFLSharp.FFLManager/FFLExceptions.cs
+ * https://github.com/aboood40091/ffl/blob/master/include/nn/ffl/FFLResult.h
+ */
+export class FFLResultException extends Error {
+	public result: number | FFLResult;
+
+	/**
+	 * @param {number|FFLResult} result - The returned {@link FFLResult}.
+	 * @param {string} [funcName] - The name of the function that was called.
+	 * @param {string} [message] - An optional message for the exception.
+	 */
+	constructor(result: number | FFLResult, funcName: string, message: string) {
+		if (!message) {
+			if (funcName) {
+				message = `${funcName} failed with FFLResult: ${result}`;
+			} else {
+				message = `From FFLResult: ${result}`;
+			}
+		}
+		super(message);
+		/** The stored {@link FFLResult} code. */
+		this.result = result;
+	}
+
+	/**
+	 * Throws an exception if the {@link FFLResult} is not OK.
+	 * @param {number} result - The {@link FFLResult} from an FFL function.
+	 * @param {string} [funcName] - The name of the function that was called.
+	 * @throws {FFLResultException|FFLResultWrongParam|FFLResultBroken|FFLResultNotAvailable|FFLResultFatal}
+	 */
+	static handleResult(result: number, funcName: string) {
+		switch (result) {
+			case FFLResult.ERROR: // FFL_RESULT_WRONG_PARAM
+				throw new FFLResultWrongParam(funcName);
+			case FFLResult.FILE_INVALID: // FFL_RESULT_BROKEN
+				throw new FFLResultBroken(funcName, '');
+			case FFLResult.MANAGER_NOT_CONSTRUCT: // FFL_RESULT_NOT_AVAILABLE
+				throw new FFLResultNotAvailable(funcName);
+			case FFLResult.FILE_LOAD_ERROR: // FFL_RESULT_FATAL
+				throw new FFLResultFatal(funcName);
+			case FFLResult.OK: // FFL_RESULT_OK
+				return; // All is OK.
+			default:
+				throw new FFLResultException(result, funcName, '');
+		}
+	}
+}
+
+/**
+ * Exception reflecting FFL_RESULT_WRONG_PARAM / FFL_RESULT_ERROR.
+ * This is the most common error thrown in FFL. It usually
+ * means that input parameters are invalid.
+ * So many cases this is thrown: parts index is out of bounds,
+ * CharModelCreateParam is malformed, FFLDataSource is invalid, FFLInitResEx
+ * parameters are null or invalid... Many different causes, very much an annoying error.
+ */
+export class FFLResultWrongParam extends FFLResultException {
+	/** @param {string} [funcName] - Name of the function where the result originated. */
+	constructor(funcName: string) {
+		super(FFLResult.ERROR, funcName, `${funcName} returned FFL_RESULT_WRONG_PARAM. This usually means parameters going into that function were invalid.`);
+	}
+}
+
+/** Exception reflecting FFL_RESULT_BROKEN / FFL_RESULT_FILE_INVALID. */
+export class FFLResultBroken extends FFLResultException {
+	/**
+	 * @param {string} [funcName] - Name of the function where the result originated.
+	 * @param {string} [message] - An optional message for the exception.
+	 */
+	constructor(funcName: string, message: string) {
+		super(FFLResult.FILE_INVALID, funcName, message ? message : `${funcName} returned FFL_RESULT_BROKEN. This usually indicates invalid underlying data.`);
+	}
+}
+
+/** Exception when resource header verification fails. */
+export class BrokenInitRes extends FFLResultBroken {
+	constructor() {
+		super('FFLInitRes', 'The header for the FFL resource is probably invalid. Check the version and magic, should be "FFRA" or "ARFF".');
+	}
+}
+
+/**
+ * Thrown when: CRC16 fails, CharInfo verification fails, or failing to fetch from a database (impossible here)
+ */
+export class BrokenInitModel extends FFLResultBroken {
+	constructor() {
+		super('FFLInitCharModelCPUStep', 'FFLInitCharModelCPUStep failed probably because your data failed CRC or CharInfo verification (FFLiVerifyCharInfoWithReason).');
+	}
+}
+
+/**
+ * Exception reflecting FFL_RESULT_NOT_AVAILABLE / FFL_RESULT_MANAGER_NOT_CONSTRUCT.
+ * This is seen when FFLiManager is not constructed, which it is not when FFLInitResEx fails
+ * or was never called to begin with.
+ */
+export class FFLResultNotAvailable extends FFLResultException {
+	/** @param {string} [funcName] - Name of the function where the result originated. */
+	constructor(funcName: string) {
+		super(FFLResult.MANAGER_NOT_CONSTRUCT, funcName, `Tried to call FFL function ${funcName} when FFLManager is not constructed (FFL is not initialized properly).`);
+	}
+}
+
+/**
+ * Exception reflecting FFL_RESULT_FATAL / FFL_RESULT_FILE_LOAD_ERROR.
+ * This error indicates database file load errors or failures from FFLiResourceLoader (decompression? misalignment?)
+ */
+export class FFLResultFatal extends FFLResultException {
+	/** @param {string} [funcName] - Name of the function where the result originated. */
+	constructor(funcName: string) {
+		super(FFLResult.FILE_LOAD_ERROR, funcName, `Failed to uncompress or load a specific asset from the FFL resource file during call to ${funcName}`);
+	}
+}
+
+/**
+ * Exception thrown by the result of FFLiVerifyCharInfoWithReason.
+ * Reference: https://github.com/aboood40091/ffl/blob/master/include/nn/ffl/detail/FFLiCharInfo.h#L90
+ */
+export class FFLiVerifyReasonException extends Error {
+	public result: number;
+
+	/** @param {number} result - The FFLiVerifyReason code from FFLiVerifyCharInfoWithReason. */
+	constructor(result: number) {
+		super(`FFLiVerifyCharInfoWithReason (CharInfo verification) failed with result: ${result}`);
+		/** The stored FFLiVerifyReason code. */
+		this.result = result;
+	}
+}
+
+/**
+ * Exception thrown when the mask is set to an expression that
+ * the {@link CharModel} was never initialized to, which can't happen
+ * because that mask texture does not exist on the {@link CharModel}.
+ * @augments {Error}
+ */
+export class ExpressionNotSet extends Error {
+	public expression: FFLExpression;
+
+	/** @param {FFLExpression} expression - The attempted expression. */
+	constructor(expression: FFLExpression) {
+		super(`Attempted to set expression ${expression}, but the mask for that expression does not exist. You must reinitialize the CharModel with this expression in the expression flags before using it.`);
+		this.expression = expression;
+	}
+}

--- a/src/ExportTexture.ts
+++ b/src/ExportTexture.ts
@@ -1,0 +1,107 @@
+import * as THREE from 'three';
+import Renderer from './renderer';
+import { _getIdentCamera } from './RenderTargetUtils';
+
+/**
+ * Saves the current renderer state and returns an object to restore it later.
+ * @param {Renderer} renderer - The renderer to save state from.
+ * @returns {{target: import('three').RenderTarget|null,
+ * colorSpace: import('three').ColorSpace, size: import('three').Vector2}}
+ * The saved state object.
+ */
+export function _saveRendererState(renderer: Renderer): { target: THREE.RenderTarget | null; colorSpace: THREE.ColorSpace; size: THREE.Vector2 } {
+	const size = new THREE.Vector2();
+	renderer.getSize(size);
+
+	return {
+		target: renderer.getRenderTarget(),
+		colorSpace: renderer.outputColorSpace as THREE.ColorSpace,
+		size
+	};
+}
+
+/**
+ * Restores a renderer's state from a saved state object.
+ * @param {Renderer} renderer - The renderer to restore state to.
+ * @param {{target: import('three').RenderTarget|null,
+ * colorSpace: import('three').ColorSpace, size: import('three').Vector2}} state -
+ * The saved state object.
+ */
+export function _restoreRendererState(renderer: Renderer, state: { target: THREE.RenderTarget | null; colorSpace: THREE.ColorSpace; size: THREE.Vector2 }): void {
+	renderer.setRenderTarget(state.target);
+	renderer.outputColorSpace = state.colorSpace;
+	renderer.setSize(state.size.x, state.size.y, false);
+}
+
+/**
+ * Copies the renderer's swapchain to a canvas.
+ * @param {Renderer} renderer - The renderer.
+ * @param {HTMLCanvasElement} [canvas] - Optional target canvas. If not provided, a new one is created.
+ * @returns {HTMLCanvasElement} The canvas containing the rendered output.
+ * @throws {Error} Throws if the canvas is defined but invalid.
+ */
+export function _copyRendererToCanvas(renderer: Renderer, canvas?: HTMLCanvasElement): HTMLCanvasElement {
+	const sourceCanvas = renderer.domElement;
+	// If the target canvas is not simply undefined, it's null, then error out.
+	if (canvas !== undefined && !(canvas instanceof HTMLCanvasElement)) {
+		throw new Error('copyRendererToCanvas: canvas is neither a valid canvas nor undefined.');
+	}
+	const targetCanvas = canvas || document.createElement('canvas');
+	targetCanvas.width = sourceCanvas.width;
+	targetCanvas.height = sourceCanvas.height;
+	// NOTE: Line below guarantees the canvas to be valid.
+	(targetCanvas.getContext('2d') as CanvasRenderingContext2D).drawImage(sourceCanvas, 0, 0);
+
+	return targetCanvas;
+}
+
+// --------------- textureToCanvas(texture, renderer, options) ---------------
+/**
+ * Renders a texture to a canvas. If no canvas is provided, a new one is created.
+ * @param {import('three').Texture} texture - The texture to render.
+ * @param {Renderer} renderer - The renderer.
+ * @param {Object} [options] - Options for canvas output.
+ * @param {boolean} [options.flipY] - Flip the Y axis. Default is oriented for OpenGL.
+ * @param {HTMLCanvasElement} [options.canvas] - Optional canvas to draw into.
+ * Creates a new canvas if this does not exist.
+ * @returns {HTMLCanvasElement} The canvas containing the rendered texture.
+ */
+export function textureToCanvas(texture: THREE.Texture, renderer: Renderer, options: { flipY: boolean; canvas?: HTMLCanvasElement; } = { flipY: true }): HTMLCanvasElement {
+	const { flipY } = options;
+	let { canvas } = options;
+	// Create a new scene using a full-screen quad.
+	const scene = new THREE.Scene();
+	scene.background = null; // Transparent background.
+	// Assign a transparent, textured, and double-sided material.
+	const material = new THREE.MeshBasicMaterial({
+		side: THREE.DoubleSide, map: texture, transparent: true
+	});
+	/** Full-screen quad. */
+	const plane = new THREE.PlaneGeometry(2, 2);
+	const mesh = new THREE.Mesh(plane, material);
+	scene.add(mesh);
+	/** Ortho camera filling whole screen. */
+	const camera = _getIdentCamera(flipY);
+
+	// Get previous render target, color space, and size.
+	const state = _saveRendererState(renderer);
+
+	// Render to the main canvas to extract pixels.
+	renderer.setRenderTarget(null); // Render to primary target.
+	// Get width and set it on renderer.
+	const { width, height } = texture.image;
+	renderer.setSize(width, height, false);
+	// Use working color space.
+	renderer.outputColorSpace = THREE.ColorManagement ? THREE.ColorManagement.workingColorSpace : '';
+	renderer.render(scene, camera);
+
+	canvas = _copyRendererToCanvas(renderer, canvas); // Populate canvas.
+
+	// Cleanup and restore renderer state.
+	material.dispose();
+	plane.dispose();
+	scene.remove(mesh);
+	_restoreRendererState(renderer, state);
+
+	return canvas; // Either a new canvas or the same one.
+}

--- a/src/ExportTexture.ts
+++ b/src/ExportTexture.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
-import Renderer from './renderer';
-import { _getIdentCamera } from './RenderTargetUtils';
+import Renderer from '@/renderer';
+import { _getIdentCamera } from '@/RenderTargetUtils';
 
 /**
  * Saves the current renderer state and returns an object to restore it later.

--- a/src/GeometryConversion.ts
+++ b/src/GeometryConversion.ts
@@ -1,0 +1,177 @@
+import * as THREE from 'three';
+
+/**
+ * Modifies a BufferGeometry in place to be compatible with glTF.
+ * It currently: deinterleaves attributes, converts half-float to float,
+ * and converts signed integer formats (not uint8 for color) to float.
+ * Attributes named "normal" are reduced to three components.
+ * @param {import('three').BufferGeometry} geometry - The BufferGeometry to modify in place.
+ * @throws {Error} Throws if an unsupported attribute format is encountered.
+ */
+export function convGeometryToGLTFCompatible(geometry: THREE.BufferGeometry): void {
+	if (!(geometry instanceof THREE.BufferGeometry) || !geometry.attributes) {
+		throw new Error('convGeometryToGLTFCompatible: geometry is not BufferGeometry with attributes.');
+	}
+
+	// Process each attribute in the geometry.
+	for (const [key, attr] of Object.entries(geometry.attributes)) {
+		// If the attribute is interleaved, deinterleave it.
+		const bufferAttribute = attr instanceof THREE.InterleavedBufferAttribute
+			? interleavedBufferAttributeToBufferAttribute(attr)
+			: attr;
+		const array = bufferAttribute.array;
+		const originalItemSize = bufferAttribute.itemSize;
+		const count = bufferAttribute.count;
+
+		/**
+		 * Size of the target attribute. Force vec3 for "normal".
+		 * @type {number}
+		 */
+		const targetItemSize = key.toLowerCase() === 'normal' ? 3 : originalItemSize;
+
+		/** @type {Float32Array|Uint8Array} */ let newArray;
+		/** Whether the value is normalized. False by default for float attributes. */
+		let normalized = false;
+
+		if (array instanceof Float32Array) {
+			// If already float32, only adjust components if needed.
+			newArray = targetItemSize === originalItemSize
+				? array
+				: copyFloat32WithReducedComponents(array, count, originalItemSize, targetItemSize);
+		} else if (array instanceof Uint16Array) {
+			// Assume half-float values. Three.js >=160 is required for them.
+			const float32Full = convertHalfFloatArrayToFloat32(array);
+			newArray = targetItemSize === originalItemSize
+				? float32Full
+				: copyFloat32WithReducedComponents(float32Full,
+					count, originalItemSize, targetItemSize);
+		} else if (array instanceof Int8Array) {
+			// Convert SNORM to float in the range [-1,1]. For normals, only use first 3 components.
+			newArray = convertSNORMToFloat32(array, count, originalItemSize, targetItemSize);
+			// normalized = true; // Normals should be normalized?
+		} else if (array instanceof Uint8Array) {
+			// Likely color data in UNORM, leave as-is.
+			newArray = array;
+			normalized = true; // Not converted to float.
+		} else {
+			throw new Error(`convGeometryToGLTFCompatible: Unsupported attribute data type for ${key}: ${array.constructor.name}`);
+		}
+
+		// Also not sure if this will leak from the old attribute or not. (Don't think so)
+		geometry.setAttribute(key, new THREE.BufferAttribute(newArray, targetItemSize, normalized));
+	}
+}
+
+/**
+ * Deinterleaves an InterleavedBufferAttribute into a standalone BufferAttribute.
+ * @param {import('three').InterleavedBufferAttribute} attr - The interleaved attribute.
+ * @returns {import('three').BufferAttribute} A new BufferAttribute containing deinterleaved data.
+ */
+export function interleavedBufferAttributeToBufferAttribute(attr: THREE.InterleavedBufferAttribute): THREE.BufferAttribute {
+	const { itemSize, count } = attr;
+	// eslint-disable-next-line jsdoc/valid-types -- TODO fix "syntax error in type"
+	const dest = new (attr.array.constructor as new (length: number) => typeof attr.array)(count * itemSize);
+
+	for (let i = 0; i < count; i++) {
+		for (let j = 0; j < itemSize; j++) {
+			dest[i * itemSize + j] = attr.getComponent(i, j);
+		}
+	}
+	return new THREE.BufferAttribute(dest, itemSize);
+}
+
+/**
+ * Creates a new Float32Array by copying only a subset of components per vertex.
+ * @param {Float32Array} src - The source Float32Array.
+ * @param {number} count - Number of vertices.
+ * @param {number} srcItemSize - Original components per vertex.
+ * @param {number} targetItemSize - Number of components to copy per vertex.
+ * @returns {Float32Array} A new Float32Array with reduced component count.
+ */
+export function copyFloat32WithReducedComponents(src: Float32Array, count: number, srcItemSize: number, targetItemSize: number): Float32Array {
+	const dst = new Float32Array(count * targetItemSize);
+	for (let i = 0; i < count; i++) {
+		for (let j = 0; j < targetItemSize; j++) {
+			dst[i * targetItemSize + j] = src[i * srcItemSize + j];
+		}
+	}
+	return dst;
+}
+
+/**
+ * Converts a 16-bit half-float value to a 32-bit float.
+ * @param {number} half - The half-float value.
+ * @returns {number} The corresponding 32-bit float value.
+ */
+export function halfToFloat(half: number): number {
+	const sign = (half & 0x8000) >> 15;
+	const exponent = (half & 0x7C00) >> 10;
+	const mantissa = half & 0x03FF;
+
+	if (exponent === 0) {
+		// Subnormal number.
+		return (sign ? -1 : 1) * Math.pow(2, -14) * (mantissa / Math.pow(2, 10));
+	} else if (exponent === 0x1F) {
+		// NaN or Infinity.
+		return mantissa ? NaN : ((sign ? -1 : 1) * Infinity);
+	}
+	// Normalized number.
+	return (sign ? -1 : 1) *
+		Math.pow(2, exponent - 15) *
+		(1 + mantissa / 1024);
+}
+
+/**
+ * Converts a Uint16Array assumed to represent half-float values into a Float32Array.
+ * @param {Uint16Array} halfArray - The Uint16Array of half-float values.
+ * @returns {Float32Array} A Float32Array with converted float values.
+ */
+export function convertHalfFloatArrayToFloat32(halfArray: Uint16Array): Float32Array {
+	const floatArray = new Float32Array(halfArray.length);
+	for (let i = 0; i < halfArray.length; i++) {
+		floatArray[i] = halfToFloat(halfArray[i]);
+	}
+	return floatArray;
+}
+
+/**
+ * Converts an Int8Array of SNORM values to a Float32Array.
+ * If the targetItemSize is less than the original (e.g. for normals), only the first targetItemSize
+ * components of each vertex are copied.
+ * @param {Int8Array} src - The source Int8Array.
+ * @param {number} count - Number of vertices.
+ * @param {number} srcItemSize - Original number of components per vertex.
+ * @param {number} targetItemSize - Number of components per vertex for the output.
+ * @returns {Float32Array} A Float32Array with converted values.
+ */
+export function convertSNORMToFloat32(src: Int8Array, count: number, srcItemSize: number, targetItemSize: number): Float32Array {
+	const dst = new Float32Array(count * targetItemSize);
+
+	for (let i = 0; i < count; i++) {
+		const baseIn = i * srcItemSize;
+		const baseOut = i * targetItemSize;
+
+		if (targetItemSize === 4 && srcItemSize === 4) {
+			// Tangent case: normalize xyz, keep w
+			const x = src[baseIn] / 127;
+			const y = src[baseIn + 1] / 127;
+			const z = src[baseIn + 2] / 127;
+			const w = src[baseIn + 3] / 127;
+
+			const mag = Math.sqrt(x * x + y * y + z * z) || 1;
+
+			dst[baseOut] = x / mag;
+			dst[baseOut + 1] = y / mag;
+			dst[baseOut + 2] = z / mag;
+			dst[baseOut + 3] = w;
+		} else {
+			// General case: convert up to targetItemSize components directly
+			for (let j = 0; j < targetItemSize; j++) {
+				const val = src[baseIn + j];
+				dst[baseOut + j] = val < 0 ? val / 128 : val / 127;
+			}
+		}
+	}
+
+	return dst;
+}

--- a/src/Init.ts
+++ b/src/Init.ts
@@ -1,0 +1,245 @@
+import { FFLResourceType, FFLResult } from "./enums";
+import { BrokenInitRes, FFLResultException } from "./Exceptions";
+import Module from "./Module";
+import { FFLResourceDesc } from "./StructFFLiCharModel";
+
+/**
+ * Loads data from TypedArray or fetch response directly into Emscripten heap.
+ * If passed a fetch response, it streams it directly into memory and avoids copying.
+ * @param {ArrayBuffer|Uint8Array|Response} resource - The resource data.
+ * Use a Fetch response to stream directly, or a Uint8Array if you only have the raw bytes.
+ * @param {Module} module - The Emscripten module instance.
+ * @returns {Promise<{pointer: number, size: number}>} Pointer and size of the allocated heap memory.
+ * @throws {Error} resource must be a Uint8Array or fetch that is streamable and has Content-Length.
+ * @private
+ */
+async function _loadDataIntoHeap(resource: ArrayBuffer | Uint8Array | Response, module: Module): Promise<{ pointer: number; size: number; }> {
+	// These need to be accessible by the catch statement:
+	let heapSize;
+	let heapPtr;
+	try {
+		// Copy resource into heap.
+		if (resource instanceof ArrayBuffer) {
+			resource = new Uint8Array(resource);
+		}
+		if (resource instanceof Uint8Array) {
+			// Comes in as Uint8Array, allocate and set it.
+			heapSize = resource.length;
+			heapPtr = module._malloc(heapSize);
+			console.debug(`_loadDataIntoHeap: Loading from buffer. Size: ${heapSize}, Pointer: ${heapPtr}`);
+			// Allocate and set this area in the heap as the passed buffer.
+			module.HEAPU8.set(resource, heapPtr);
+		} else if (resource instanceof Response) {
+			// Handle as fetch response.
+			if (!resource.ok) {
+				throw new Error(`_loadDataIntoHeap: Failed to fetch resource at URL = ${resource.url}, response code = ${resource.status}`);
+			}
+			// Throw an error if it is not a streamable response.
+			if (!resource.body) {
+				throw new Error(`_loadDataIntoHeap: Fetch response body is null (resource.body = ${resource.body})`);
+			}
+			// Get the total size of the resource from the headers.
+			const contentLength = resource.headers.get('Content-Length');
+			if (!contentLength) {
+				// Cannot stream the response. Read as ArrayBuffer and reinvoke function.
+				console.debug('_loadDataIntoHeap: Fetch response is missing Content-Length, falling back to reading as ArrayBuffer.');
+				return _loadDataIntoHeap(await resource.arrayBuffer(), module);
+			}
+
+			// Allocate into heap using the Content-Length.
+			heapSize = parseInt(contentLength, 10);
+			heapPtr = module._malloc(heapSize);
+
+			console.debug(`loadDataIntoHeap: Streaming from fetch response. Size: ${heapSize}, pointer: ${heapPtr}, URL: ${resource.url}`);
+
+			// Begin reading and streaming chunks into the heap.
+			const reader = resource.body.getReader();
+			let offset = heapPtr;
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) {
+					break;
+				}
+				// Copy value directly into HEAPU8 with offset.
+				module.HEAPU8.set(value, offset);
+				offset += value.length;
+			}
+		} else {
+			throw new Error('loadDataIntoHeap: type is not Uint8Array or Response');
+		}
+
+		return { pointer: heapPtr, size: heapSize };
+	} catch (error) {
+		// Free memory upon exception, if allocated.
+		if (heapPtr) {
+			module._free(heapPtr);
+		}
+		throw error;
+	}
+}
+
+// ----------------- initializeFFL(resource, moduleOrPromise) -----------------
+/**
+ * Initializes FFL by copying the resource into heap and calling FFLInitRes.
+ * It will first wait for the Emscripten module to be ready.
+ * @param {Uint8Array|Response} resource - The FFL resource data. Use a Uint8Array
+ * if you have the raw bytes, or a fetch response containing the FFL resource file.
+ * @param {Module|Promise<Module>|function(): Promise<Module>} moduleOrPromise - The Emscripten module
+ * by itself (window.Module when MODULARIZE=0), as a promise (window.Module() when MODULARIZE=1),
+ * or as a function returning a promise (window.Module when MODULARIZE=1).
+ * @returns {Promise<{module: Module, resourceDesc: FFLResourceDesc}>} Resolves when FFL is fully initialized,
+ * returning the final Emscripten {@link Module} instance and the {@link FFLResourceDesc} object
+ * that can later be passed into {@link exitFFL}.
+ */
+async function initializeFFL(resource: Uint8Array | Response, moduleOrPromise: Module | Promise<Module> | (() => Promise<Module>)): Promise<{ module: Module; resourceDesc: ReturnType<typeof FFLResourceDesc.unpack> }> {
+	console.debug('initializeFFL: Entrypoint, waiting for module to be ready.');
+
+	/**
+	 * Pointer to the FFLResourceDesc structure to free when FFLInitRes call is done.
+	 * @type {number}
+	 */
+	let resourceDescPtr: number;
+	/** Frees the FFLResourceDesc - not the resources it POINTS to unlike _freeResourceDesc. */
+	function freeResDesc(): void {
+		if (resourceDescPtr) {
+			// Free FFLResourceDesc, unused after init.
+			module._free(resourceDescPtr);
+		}
+	}
+	/** Resource type to load single resource into. */
+	const resourceType = FFLResourceType.HIGH;
+
+	/**
+	 * The Emscripten Module instance to set and return at the end.
+	 * @type {Module}
+	 */
+	let module: Module;
+	// Resolve moduleOrPromise to the Module instance.
+	if (typeof moduleOrPromise === 'function') {
+		// Assume this function gets the promise of the module.
+		moduleOrPromise = moduleOrPromise();
+	}
+	if (moduleOrPromise instanceof Promise) {
+		// Await if this is now a promise.
+		module = await moduleOrPromise;
+	} else {
+		// Otherwise, assume it is already the module.
+		module = moduleOrPromise;
+	}
+
+	// Wait for the Emscripten runtime to be ready if it isn't already.
+	if (!module.calledRun && !module.onRuntimeInitialized) {
+		// calledRun is not defined. Set onRuntimeInitialized and wait for it in a new promise.
+		await new Promise((resolve) => {
+			/** If onRuntimeInitialized is not defined on module, add it. */
+			module.onRuntimeInitialized = () => {
+				console.debug('initializeFFL: Emscripten runtime initialized, resolving.');
+				resolve(null);
+			};
+			console.debug(`initializeFFL: module.calledRun: ${module.calledRun}, module.onRuntimeInitialized:\n${module.onRuntimeInitialized}\n // ^^ assigned and waiting.`);
+			// If you are stuck here, the object passed in may not actually be an Emscripten module?
+		});
+	} else {
+		console.debug('initializeFFL: Assuming module is ready.');
+	}
+
+	// Module should be ready after this point, begin loading the resource.
+	/** @type {FFLResourceDesc|null} */
+	let resourceDesc = null;
+	try {
+		// If resource is itself a promise (fetch() result), wait for it to finish.
+		if (resource instanceof Promise) {
+			resource = await resource;
+		}
+
+		// Load the resource (Uint8Array/fetch Response) into heap.
+		const { pointer: heapPtr, size: heapSize } = await _loadDataIntoHeap(resource, module);
+		console.debug(`initializeFFL: Resource loaded into heap. Pointer: ${heapPtr}, Size: ${heapSize}`);
+
+		// Initialize and pack FFLResourceDesc.
+		resourceDesc = { pData: [0, 0], size: [0, 0] };
+		resourceDesc.pData[resourceType] = heapPtr;
+		resourceDesc.size[resourceType] = heapSize;
+
+		const resourceDescData = FFLResourceDesc.pack(resourceDesc);
+		resourceDescPtr = module._malloc(FFLResourceDesc.size); // Freed by freeResDesc.
+		module.HEAPU8.set(resourceDescData, resourceDescPtr);
+
+		// Call FFL initialization using: FFL_FONT_REGION_JP_US_EU = 0
+		const result = module._FFLInitRes(0, resourceDescPtr);
+
+		// Handle failed result.
+		if (result === FFLResult.FILE_INVALID) { // FFL_RESULT_BROKEN
+			throw new BrokenInitRes();
+		}
+		FFLResultException.handleResult(result, 'FFLInitRes');
+
+		// Set required globals in FFL.
+		module._FFLInitResGPUStep(); // CanInitCharModel will fail if not called.
+		module._FFLSetNormalIsSnorm8_8_8_8(true); // Set normal format to FFLiSnorm8_8_8_8.
+		module._FFLSetTextureFlipY(true); // Set textures to be flipped for OpenGL.
+
+		// Requires refactoring:
+		// module._FFLSetScale(0.1); // Sets model scale back to 1.0.
+		// module._FFLSetLinearGammaMode(1); // Use linear gamma.
+		// I don't think ^^ will work because the shaders need sRGB
+	} catch (error) {
+		// Cleanup on error.
+		_freeResourceDesc(resourceDesc, module);
+		freeResDesc();
+		console.error('initializeFFL failed:', error);
+		throw error;
+	} finally {
+		// Always free the FFLResourceDesc struct itself.
+		freeResDesc();
+	}
+
+	// Return final Emscripten module and FFLResourceDesc object.
+	return {
+		module: module,
+		resourceDesc: resourceDesc
+	};
+}
+
+/**
+ * Frees all pData pointers within {@link FFLResourceDesc}.
+ * @param {FFLResourceDesc|null} desc - {@link FFLResourceDesc} to free pointers from.
+ * @param {Module} module - Emscripten module to call _free on.
+ * @package
+ */
+export function _freeResourceDesc(desc: ReturnType<typeof FFLResourceDesc.unpack> | null, module: Module): void {
+	if (!desc || !desc.pData) {
+		return;
+	}
+	desc.pData.forEach((ptr: number, i: number) => {
+		if (ptr) {
+			module._free(ptr);
+			desc.pData[i] = 0;
+		}
+	});
+}
+
+// ---------------------- exitFFL(module, resourceDesc) ----------------------
+/**
+ * @param {Module} module - Emscripten module.
+ * @param {FFLResourceDesc} resourceDesc - The FFLResourceDesc received from {@link initializeFFL}.
+ * @public
+ * @todo TODO: Needs to somehow destroy Emscripten instance.
+ */
+export function exitFFL(module: Module, resourceDesc: ReturnType<typeof FFLResourceDesc.unpack>): void {
+	console.debug('exitFFL called, resourceDesc:', resourceDesc);
+
+	// All CharModels must be deleted before this point.
+	const result = module._FFLExit();
+	FFLResultException.handleResult(result, 'FFLExit');
+
+	// Free resources in heap after FFLExit().
+	_freeResourceDesc(resourceDesc, module);
+
+	// Exit the module...? Is this even necessary?
+	if (module._exit) {
+		module._exit();
+	} else {
+		console.debug('exitFFL: not calling module._exit = ', module._exit);
+	}
+}

--- a/src/Init.ts
+++ b/src/Init.ts
@@ -1,7 +1,7 @@
-import { FFLResourceType, FFLResult } from "./enums";
-import { BrokenInitRes, FFLResultException } from "./Exceptions";
-import Module from "./Module";
-import { FFLResourceDesc } from "./StructFFLiCharModel";
+import { FFLResourceType, FFLResult } from "@/enums";
+import { BrokenInitRes, FFLResultException } from "@/Exceptions";
+import { Module } from "@/Module";
+import { FFLResourceDesc } from "@/StructFFLiCharModel";
 
 /**
  * Loads data from TypedArray or fetch response directly into Emscripten heap.

--- a/src/ModelIcon.ts
+++ b/src/ModelIcon.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
-import CharModel from './CharModel';
-import Renderer from './renderer';
-import { _copyRendererToCanvas, _restoreRendererState, _saveRendererState } from './ExportTexture';
+import CharModel from '@/CharModel';
+import Renderer from '@/renderer';
+import { _copyRendererToCanvas, _restoreRendererState, _saveRendererState } from '@/ExportTexture';
 
 export enum ViewType {
 	/** Typical icon body view. */

--- a/src/ModelIcon.ts
+++ b/src/ModelIcon.ts
@@ -1,0 +1,99 @@
+import * as THREE from 'three';
+import CharModel from './CharModel';
+import Renderer from './renderer';
+import { _copyRendererToCanvas, _restoreRendererState, _saveRendererState } from './ExportTexture';
+
+export enum ViewType {
+	/** Typical icon body view. */
+	Face = 0,
+	/** FFLMakeIcon matrix */
+	MakeIcon = 1,
+	/** Custom view with 45 degree field-of-view. */
+	IconFovy45 = 2
+};
+
+// -------------- getCameraForViewType(viewType, width, height) --------------
+/**
+ * @param {ViewType} viewType - The {@link ViewType} enum value.
+ * @param {number} width - Width of the view.
+ * @param {number} height - Height of the view.
+ * @returns {import('three').PerspectiveCamera} The camera representing the view type specified.
+ * @throws {Error} not implemented (ViewType.Face)
+ */
+export function getCameraForViewType(viewType: ViewType, width = 1, height = 1): THREE.PerspectiveCamera {
+	const aspect = width / height;
+	switch (viewType) {
+		case ViewType.MakeIcon: {
+			/** rad2deg(Math.atan2(43.2 / aspect, 500) / 0.5); */
+			const fovy = 9.8762;
+			const camera = new THREE.PerspectiveCamera(fovy, aspect, 500, 1000);
+			camera.position.set(0, 34.5, 600);
+			camera.lookAt(0, 34.5, 0.0);
+			return camera;
+		}
+		case ViewType.IconFovy45: {
+			const camera = new THREE.PerspectiveCamera(45, aspect, 50, 1000);
+			camera.position.set(0, 34, 110);
+			camera.lookAt(0, 34, 0);
+			return camera;
+		}
+		default:
+			throw new Error('getCameraForViewType: not implemented');
+	}
+}
+
+// ----------- makeIconFromCharModel(charModel, renderer, options) -----------
+/**
+ * Creates an icon of the CharModel with the specified view type.
+ * @param {CharModel} charModel - The CharModel instance.
+ * @param {Renderer} renderer - The renderer.
+ * @param {Object} [options] - Optional settings for rendering the icon.
+ * @param {ViewType} [options.viewType] - The view type that the camera derives from.
+ * @param {number} [options.width] - Desired icon width in pixels.
+ * @param {number} [options.height] - Desired icon height in pixels.
+ * @param {import('three').Scene} [options.scene] - Optional scene
+ * if you want to provide your own (e.g., with background, or models).
+ * @param {import('three').Camera} [options.camera] - Optional camera
+ * to use instead of the one derived from {@link ViewType}.
+ * @param {HTMLCanvasElement} [options.canvas] - Optional canvas
+ * to draw into. Creates a new canvas if this does not exist.
+ * @returns {HTMLCanvasElement} The canvas containing the icon.
+ */
+export function makeIconFromCharModel(charModel: CharModel, renderer: Renderer, options: Record<string, any> = {}): HTMLCanvasElement {
+	// Set locals from options object.
+	let {
+		viewType = ViewType.MakeIcon,
+		width = 256,
+		height = 256,
+		scene,
+		camera,
+		canvas
+	} = options;
+
+	// Create an offscreen scene for the icon if one is not provided.
+	if (!scene) {
+		scene = new THREE.Scene();
+		scene.background = null; // Transparent background.
+	}
+	// Add meshes from the CharModel.
+	scene.add(charModel.meshes.clone());
+	// If the meshes aren't cloned then they disappear from the
+	// primary scene, however geometry/material etc are same
+
+	// Get camera based on viewType parameter.
+	if (!camera) {
+		camera = getCameraForViewType(viewType);
+	}
+
+	const state = _saveRendererState(renderer);
+
+	renderer.setRenderTarget(null); // Switch to primary target.
+	renderer.setSize(width, height, false);
+	renderer.render(scene, camera); // Render scene.
+
+	canvas = _copyRendererToCanvas(renderer, canvas); // Populate canvas.
+
+	_restoreRendererState(renderer, state);
+	return canvas;
+	// Caller needs to dispose CharModel.
+}

--- a/src/ModulateTextureConversion.ts
+++ b/src/ModulateTextureConversion.ts
@@ -1,0 +1,150 @@
+import * as THREE from 'three';
+import CharModel, { MaterialConstructor } from './CharModel';
+import Renderer from './renderer';
+import { _getIdentCamera, _isWebGPU, createAndRenderToTarget } from './RenderTargetUtils';
+import { FFLModulateType } from './enums';
+
+/**
+ * Gets a plane whose color and opacity can be set.
+ * This can be used to simulate background clear, or specifically
+ * to set the background's color to a value but alpha to 0.
+ * @param {import('three').Color} color - The color of the plane.
+ * @param {number} [opacity] - The opacity of the plane, default is transparent.
+ * @returns {import('three').Mesh} The plane with the color and opacity specified.
+ * @package
+ */
+export function _getBGClearMesh(color: THREE.Color, opacity = 0.0) {
+	const plane = new THREE.PlaneGeometry(2, 2);
+	// Create mesh that has color but arbitrary alpha value.
+	return new THREE.Mesh(plane,
+		new THREE.MeshBasicMaterial({
+			color: color,
+			transparent: true,
+			opacity: opacity,
+			blending: THREE.NoBlending
+		})
+	);
+}
+
+/**
+ * Takes the texture in `material` and draws it using `materialTextureClass`, using
+ * the modulateMode property in `userData`, using the `renderer` and sets it back
+ * in the `material`. So it converts a swizzled (using modulateMode) texture to RGBA.
+ * NOTE: Does NOT handle mipmaps. But these textures
+ * usually do not have mipmaps anyway so it's fine
+ * @param {Renderer} renderer - The renderer.
+ * @param {import('three').MeshBasicMaterial} material - The original material of the mesh.
+ * @param {Object<string, *>} userData - The original mesh.geometry.userData to get modulateMode/Type from.
+ * @param {MaterialConstructor} materialTextureClass - The material class that draws the new texture.
+ * @returns {import('three').RenderTarget} The RenderTarget of the final RGBA texture.
+ */
+export function _texDrawRGBATarget(renderer: Renderer, material: THREE.MeshBasicMaterial, userData: Record<string, unknown>, materialTextureClass: MaterialConstructor) {
+	const scene = new THREE.Scene();
+	// Simulate clearing the background with this color, but opacity of 0.
+	const bgClearRGBMesh = _getBGClearMesh(material.color);
+	scene.add(bgClearRGBMesh); // Must be drawn first.
+
+	console.assert(material.map, '_texDrawRGBATarget: material.map is null or undefined');
+	/** Shortcut to the existing texture. */
+	const tex = (material.map as THREE.Texture);
+	// This material is solely for the texture itself and not the shape.
+	// It actually does not need color set on it, or modulate type (blending)
+	const texMat = new materialTextureClass({
+		map: tex,
+		modulateMode: userData.modulateMode,
+		color: material.color,
+		side: THREE.DoubleSide,
+		lightEnable: false
+	});
+	texMat.blending = THREE.NoBlending;
+	texMat.transparent = true;
+
+	const plane = new THREE.PlaneGeometry(2, 2);
+	const textureMesh = new THREE.Mesh(plane, texMat);
+	scene.add(textureMesh);
+
+	const flipY = _isWebGPU(renderer);
+	const target = createAndRenderToTarget(scene,
+		_getIdentCamera(flipY), renderer,
+		tex.image.width, tex.image.height, {
+			wrapS: tex.wrapS, wrapT: tex.wrapT, // Preserve wrap.
+			depthBuffer: false, stencilBuffer: false
+		});
+
+	(target.texture as THREE.Texture & { _target: THREE.RenderTarget })._target = target;
+
+	// Dispose previous texture and replace with this one.
+	(material.map as THREE.Texture).dispose();
+	material.map = target.texture;
+	// Set color to default and modulateMode to TEXTURE_DIRECT.
+	material.color = new THREE.Color(1, 1, 1);
+	userData.modulateMode = 1;
+
+	return target; // Caller is responsible for disposing the RenderTarget.
+}
+
+/**
+ * Converts a CharModel's textures, including ones that may be using swizzled modulateMode
+ * textures that are R/RG format, to RGBA and also applying colors, so that
+ * the CharModel can be rendered without a material that supports modulateMode.
+ * @param {CharModel} charModel - The CharModel whose textures to convert.
+ * @param {Renderer} renderer - The renderer.
+ * @param {MaterialConstructor} materialTextureClass - The material class that draws the new texture.
+ */
+export function convertModelTexturesToRGBA(charModel: CharModel, renderer: Renderer, materialTextureClass: MaterialConstructor) {
+	const convertTextureForTypes = [
+		FFLModulateType.SHAPE_CAP, FFLModulateType.SHAPE_NOSELINE, FFLModulateType.SHAPE_GLASS];
+
+	charModel.meshes.traverse((mesh) => {
+		if (!(mesh instanceof THREE.Mesh) ||
+			!mesh.geometry.userData.modulateType ||
+			!mesh.material.map ||
+			convertTextureForTypes.indexOf(mesh.geometry.userData.modulateType) === -1
+		) {
+			return;
+		}
+		const target = _texDrawRGBATarget(renderer, mesh.material,
+			mesh.geometry.userData, materialTextureClass);
+		// HACK?: Push to _maskTargets so that it will be disposed.
+		charModel._maskTargets.push(target);
+	});
+}
+
+/**
+ * Converts all textures in the CharModel that are associated
+ * with RenderTargets into THREE.DataTextures, so that the
+ * CharModel can be exported using e.g., GLTFExporter.
+ * @param {CharModel} charModel - The CharModel whose textures to convert.
+ * @param {Renderer} renderer - The renderer.
+ */
+export async function convModelTargetsToDataTex(charModel: CharModel, renderer: Renderer) {
+	charModel.meshes.traverse(async (mesh) => {
+		if (!(mesh instanceof THREE.Mesh) || !mesh.material.map) {
+			return;
+		}
+		const tex = mesh.material.map;
+		console.assert(tex.format === THREE.RGBAFormat,
+			'convModelTargetsToDataTex: found a texture that is not of format THREE.RGBAFormat, but, this function is only meant to be used if all textures in CharModel meshes are RGBA (so render targets)...');
+		/** RGBA */
+		const data = new Uint8Array(tex.image.width * tex.image.height * 4);
+		const target = /** @type {import('three').RenderTarget} */ tex._target;
+		console.assert(target, 'convModelTargetsToDataTex: mesh.material.map (texture)._target is null or undefined.');
+		await renderer.readRenderTargetPixelsAsync(target, 0, 0,
+			tex.image.width, tex.image.height);
+		// Construct new THREE.DataTexture from the read data.
+		// So... draw the texture, download it out, and upload it again.
+		const dataTex = new THREE.DataTexture(data, tex.image.width,
+			tex.image.height, THREE.RGBAFormat, THREE.UnsignedByteType);
+		// Copy wrap and filtering options.
+		dataTex.wrapS = tex.wrapS;
+		dataTex.wrapT = tex.wrapT;
+		dataTex.minFilter = tex.minFilter;
+		dataTex.magFilter = tex.magFilter;
+
+		dataTex.needsUpdate = true;
+		mesh.material.map = dataTex;
+	});
+	// The original render targets are no longer needed now, dispose them.
+	charModel.disposeTargets();
+	// Note that expressions cannot be set on the CharModel anymore.
+}

--- a/src/ModulateTextureConversion.ts
+++ b/src/ModulateTextureConversion.ts
@@ -1,8 +1,8 @@
 import * as THREE from 'three';
-import CharModel, { MaterialConstructor } from './CharModel';
-import Renderer from './renderer';
-import { _getIdentCamera, _isWebGPU, createAndRenderToTarget } from './RenderTargetUtils';
-import { FFLModulateType } from './enums';
+import CharModel, { MaterialConstructor } from '@/CharModel';
+import Renderer from '@/renderer';
+import { _getIdentCamera, _isWebGPU, createAndRenderToTarget } from '@/RenderTargetUtils';
+import { FFLModulateType } from '@/enums';
 
 /**
  * Gets a plane whose color and opacity can be set.

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -2,7 +2,7 @@
  * Emscripten "Module" type.
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c03bddd4d3c7774d00fa256a9e165d68c7534ccc/types/emscripten/index.d.ts#L26
  */
-export default interface Module {
+export interface Module {
 	onRuntimeInitialized: () => void;
 	destroy: (object: any) => void;
 	calledRun: boolean | null;

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -1,0 +1,69 @@
+/**
+ * Emscripten "Module" type.
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c03bddd4d3c7774d00fa256a9e165d68c7534ccc/types/emscripten/index.d.ts#L26
+ */
+export default interface Module {
+	onRuntimeInitialized: () => void;
+	destroy: (object: any) => void;
+	calledRun: boolean | null;
+
+	// USE_TYPED_ARRAYS == 2
+	HEAP8: Int8Array;
+	HEAPU8: Uint8Array;
+	HEAPU16: Uint16Array;
+	HEAPU32: Uint32Array;
+	HEAPF32: Float32Array;
+
+	// Runtime methods
+	_malloc: (size: number) => number;
+	_free: (ptr: number) => void;
+	addFunction: (func: (...args: any[]) => any, signature?: string) => number;
+	removeFunction: (ptr: number) => void;
+
+	// ------------------------------- FFL Bindings -------------------------------
+	_FFLInitCharModelCPUStepWithCallback: (arg1: number, arg2: number, arg3: number, arg4: number) => any;
+	_FFLInitCharModelCPUStep: (arg1: number, arg2: number, arg3: number) => any;
+	_FFLDeleteCharModel: (arg: number) => any;
+	_FFLGetDrawParamOpaFaceline: (arg: number) => any;
+	_FFLGetDrawParamOpaBeard: (arg: number) => any;
+	_FFLGetDrawParamOpaNose: (arg: number) => any;
+	_FFLGetDrawParamOpaForehead: (arg: number) => any;
+	_FFLGetDrawParamOpaHair: (arg: number) => any;
+	_FFLGetDrawParamOpaCap: (arg: number) => any;
+	_FFLGetDrawParamXluMask: (arg: number) => any;
+	_FFLGetDrawParamXluNoseLine: (arg: number) => any;
+	_FFLGetDrawParamXluGlass: (arg: number) => any;
+	_FFLSetExpression: (arg1: number, arg2: number) => any;
+	_FFLGetExpression: (arg: number) => any;
+	_FFLSetViewModelType: (arg1: number, arg2: number) => any;
+	_FFLGetBoundingBox: (arg1: number, arg2: number) => any;
+	_FFLIsAvailableExpression: (arg1: number, arg2: number) => any;
+	_FFLSetCoordinate: (arg1: number, arg2: number) => any;
+	_FFLSetScale: (arg: number) => any;
+	_FFLiGetRandomCharInfo: (arg1: number, arg2: number, arg3: number, arg4: number) => any;
+	_FFLpGetStoreDataFromCharInfo: (arg1: number, arg2: number) => any;
+	_FFLpGetCharInfoFromStoreData: (arg1: number, arg2: number) => any;
+	_FFLpGetCharInfoFromMiiDataOfficialRFL: (arg1: number, arg2: number) => any;
+	_FFLGetAdditionalInfo: (arg1: number, arg2: number, arg3: number, arg4: number, arg5: boolean) => any;
+	_FFLInitRes: (arg1: number, arg2: number) => any;
+	_FFLInitResGPUStep: () => any;
+	_FFLExit: () => any;
+	_FFLIsAvailable: () => any;
+	_FFLGetFavoriteColor: (arg1: number, arg2: number) => any;
+	_FFLSetLinearGammaMode: (arg: number) => any;
+	_FFLGetFacelineColor: (arg1: number, arg2: number) => any;
+	_FFLSetTextureFlipY: (arg: boolean) => any;
+	_FFLSetNormalIsSnorm8_8_8_8: (arg: boolean) => any;
+	_FFLSetFrontCullForFlipX: (arg: boolean) => any;
+	_FFLSetTextureCallback: (arg: number) => any;
+	_FFLiDeleteTextureTempObject: (arg: number) => any;
+	_FFLiDeleteTempObjectMaskTextures: (arg1: number, arg2: number, arg3: number) => any;
+	_FFLiDeleteTempObjectFacelineTexture: (arg1: number, arg2: number, arg3: number) => any;
+	_FFLiiGetEyeRotateOffset: (arg: number) => any;
+	_FFLiiGetEyebrowRotateOffset: (arg: number) => any;
+	_FFLiInvalidateTempObjectFacelineTexture: (arg: number) => any;
+	_FFLiInvalidatePartsTextures: (arg: number) => any;
+	_FFLiInvalidateRawMask: (arg: number) => any;
+	_FFLiVerifyCharInfoWithReason: (arg1: number, arg2: boolean) => any;
+	_exit: () => void;
+}

--- a/src/RenderTargetUtils.ts
+++ b/src/RenderTargetUtils.ts
@@ -1,0 +1,115 @@
+import * as THREE from 'three';
+import Renderer from './renderer';
+
+/**
+ * @param {Renderer} renderer - The input renderer.
+ * @returns {boolean} Whether the renderer is THREE.WebGPURenderer.
+ * @package
+ */
+export const _isWebGPU = (renderer: Renderer): boolean => 'isWebGPURenderer' in renderer;
+
+// -------------------------- getIdentCamera(flipY) --------------------------
+/**
+ * Returns an ortho camera that is effectively the same as
+ * if you used identity MVP matrix, for rendering 2D planes.
+ * @param {boolean} flipY - Flip the Y axis. Default is oriented for OpenGL.
+ * @returns {import('three').OrthographicCamera} The orthographic camera.
+ * @package
+ */
+export function _getIdentCamera(flipY = false): THREE.OrthographicCamera {
+	// Create an orthographic camera with bounds [-1, 1] in x and y.
+	const camera = new THREE.OrthographicCamera(-1, 1,
+		// Use [1, -1] except when using flipY.
+		(flipY ? -1 : 1), (flipY ? 1 : -1), 0.1, 10);
+	camera.position.z = 1;
+	return camera;
+}
+
+// - createAndRenderToTarget(scene, camera, renderer, width, height, targetOptions) -
+/**
+ * Creates a Three.js RenderTarget, renders the scene with
+ * the given camera, and returns the render target.
+ * @param {import('three').Scene} scene - The scene to render.
+ * @param {import('three').Camera} camera - The camera to use.
+ * @param {Renderer} renderer - The renderer.
+ * @param {number} width - Desired width of the target.
+ * @param {number} height - Desired height of the target.
+ * @param {Object} [targetOptions] - Optional options for the render target.
+ * @returns {import('three').RenderTarget} The render target (which contains .texture).
+ */
+export function createAndRenderToTarget(scene: THREE.Scene, camera: THREE.Camera, renderer: Renderer, width: number, height: number, targetOptions = {}): THREE.RenderTarget {
+	// Set default options for the RenderTarget.
+	const options = {
+		minFilter: THREE.LinearFilter,
+		magFilter: THREE.LinearFilter,
+		...targetOptions
+	};
+
+	const renderTarget = _isWebGPU(renderer)
+		? new THREE.RenderTarget(width, height, options)
+		: new THREE.WebGLRenderTarget(width, height, options);
+	// Get previous render target to switch back to.
+	const prevTarget = renderer.getRenderTarget();
+	// Only works on Three.js r102 and above.
+	renderer.setRenderTarget(
+		/** @type {import('three').RenderTarget} */ (renderTarget)); // Set new target.
+	renderer.render(scene, camera); // Render.
+	renderer.setRenderTarget(prevTarget); // Set previous target.
+	return renderTarget; // This needs to be disposed when done.
+}
+
+// -------------------------- disposeMeshes(target) --------------------------
+/**
+ * Disposes meshes in a {@link THREE.Object3D} and removes them from the {@link THREE.Scene} specified.
+ * @param {import('three').Scene|import('three').Object3D} group - The scene or group to dispose meshes from.
+ * @param {import('three').Scene} [scene] - The scene to remove the meshes from, if provided.
+ */
+export function disposeMany(group: THREE.Scene | THREE.Object3D, scene?: THREE.Scene): void {
+	// Taken from: https://github.com/igvteam/spacewalk/blob/21c0a9da27f121a54e0cf6c0d4a23a9cf80e6623/js/utils/utils.js#L135C10-L135C29
+
+	/**
+	 * Disposes a single material along with its texture map.
+	 * @param {import('three').MeshBasicMaterial} material - The material with `map` property to dispose.
+	 */
+	function disposeMaterial(material: THREE.MeshBasicMaterial): void {
+		// Dispose texture in material.
+		if (material.map) {
+			// console.debug('Disposing texture ', child.material.map.id);
+			// If this was created by TextureManager
+			// then it overrides dispose() to also
+			// remove itself from the TextureManager map.
+			material.map.dispose();
+		}
+		material.dispose(); // Dispose material itself.
+	}
+
+	// Traverse all children of the scene/group/THREE.Object3D.
+	group.traverse((child) => {
+		if (!(child instanceof THREE.Mesh)) {
+			// Only dispose of meshes.
+			return;
+		}
+		// Dispose geometry, material, and texture.
+		if (child.geometry) {
+			child.geometry.dispose();
+		}
+
+		if (child.material) {
+			// Dispose depending on if it is an array or not.
+			Array.isArray(child.material)
+				// Assume that materials are compatible with THREE.MeshBasicMaterial for .map.
+				? child.material.forEach((material) => {
+					disposeMaterial(/** @type {import('three').MeshBasicMaterial} */ (material));
+				})
+				: disposeMaterial(/** @type {import('three').MeshBasicMaterial} */(child.material));
+		}
+	});
+
+	// If this is a scene, remove this group/Object3D from it.
+	if (scene && scene instanceof THREE.Scene) {
+		scene.remove(group);
+	}
+
+	// Set group and its children to null to break references.
+	group.children = [];
+}

--- a/src/RenderTargetUtils.ts
+++ b/src/RenderTargetUtils.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import Renderer from './renderer';
+import Renderer from '@/renderer';
 
 /**
  * @param {Renderer} renderer - The input renderer.

--- a/src/StructFFLiCharModel.ts
+++ b/src/StructFFLiCharModel.ts
@@ -1,5 +1,6 @@
-import { _uintptr, FFLDrawParam, FFLVec3 } from './structs';
-import { FFLExpression, FFLModelFlag, FFLResourceType, FFLiShapeType } from './enums';
+import * as _ from '../struct-fu.js';
+import { _uintptr, FFLDrawParam, FFLVec3 } from '@/structs';
+import { FFLExpression, FFLModelFlag, FFLResourceType, FFLiShapeType } from '@/enums';
 
 /**
  * @typedef {Object} FFLiCharInfo

--- a/src/StructFFLiCharModel.ts
+++ b/src/StructFFLiCharModel.ts
@@ -1,0 +1,434 @@
+import { _uintptr, FFLDrawParam, FFLVec3 } from './structs';
+import { FFLExpression, FFLModelFlag, FFLResourceType, FFLiShapeType } from './enums';
+
+/**
+ * @typedef {Object} FFLiCharInfo
+ * @property {number} miiVersion
+ * @property {number} faceType
+ * @property {number} faceColor
+ * @property {number} faceTex
+ * @property {number} faceMake
+ * @property {number} hairType
+ * @property {number} hairColor
+ * @property {number} hairFlip
+ * @property {number} eyeType
+ * @property {number} eyeColor
+ * @property {number} eyeScale
+ * @property {number} eyeAspect
+ * @property {number} eyeRotate
+ * @property {number} eyeX
+ * @property {number} eyeY
+ * @property {number} eyebrowType
+ * @property {number} eyebrowColor
+ * @property {number} eyebrowScale
+ * @property {number} eyebrowAspect
+ * @property {number} eyebrowRotate
+ * @property {number} eyebrowX
+ * @property {number} eyebrowY
+ * @property {number} noseType
+ * @property {number} noseScale
+ * @property {number} noseY
+ * @property {number} mouthType
+ * @property {number} mouthColor
+ * @property {number} mouthScale
+ * @property {number} mouthAspect
+ * @property {number} mouthY
+ * @property {number} beardMustache
+ * @property {number} beardType
+ * @property {number} beardColor
+ * @property {number} beardScale
+ * @property {number} beardY
+ * @property {number} glassType
+ * @property {number} glassColor
+ * @property {number} glassScale
+ * @property {number} glassY
+ * @property {number} moleType
+ * @property {number} moleScale
+ * @property {number} moleX
+ * @property {number} moleY
+ * @property {number} height
+ * @property {number} build
+ * @property {string} name
+ * @property {string} creator
+ * @property {number} gender
+ * @property {number} birthMonth
+ * @property {number} birthDay
+ * @property {number} favoriteColor
+ * @property {number} favorite
+ * @property {number} copyable
+ * @property {number} ngWord
+ * @property {number} localonly
+ * @property {number} regionMove
+ * @property {number} fontRegion
+ * @property {number} roomIndex
+ * @property {number} positionInRoom
+ * @property {number} birthPlatform
+ * @property {Array<number>} createID
+ * @property {number} padding_0
+ * @property {number} authorType
+ * @property {Array<number>} authorID
+ */
+/** @type {import('./struct-fu').StructInstance<FFLiCharInfo>} */
+export const FFLiCharInfo = _.struct([
+	_.int32le('miiVersion'),
+	// faceline
+	_.int32le('faceType'),
+	_.int32le('faceColor'),
+	_.int32le('faceTex'),
+	_.int32le('faceMake'),
+	// hair
+	_.int32le('hairType'),
+	_.int32le('hairColor'),
+	_.int32le('hairFlip'),
+	// eye
+	_.int32le('eyeType'),
+	_.int32le('eyeColor'),
+	_.int32le('eyeScale'),
+	_.int32le('eyeAspect'),
+	_.int32le('eyeRotate'),
+	_.int32le('eyeX'),
+	_.int32le('eyeY'),
+	// eyebrow
+	_.int32le('eyebrowType'),
+	_.int32le('eyebrowColor'),
+	_.int32le('eyebrowScale'),
+	_.int32le('eyebrowAspect'),
+	_.int32le('eyebrowRotate'),
+	_.int32le('eyebrowX'),
+	_.int32le('eyebrowY'),
+	// nose
+	_.int32le('noseType'),
+	_.int32le('noseScale'),
+	_.int32le('noseY'),
+	// mouth
+	_.int32le('mouthType'),
+	_.int32le('mouthColor'),
+	_.int32le('mouthScale'),
+	_.int32le('mouthAspect'),
+	_.int32le('mouthY'),
+	// beard
+	_.int32le('beardMustache'),
+	_.int32le('beardType'),
+	_.int32le('beardColor'),
+	_.int32le('beardScale'),
+	_.int32le('beardY'),
+	// glass
+	_.int32le('glassType'),
+	_.int32le('glassColor'),
+	_.int32le('glassScale'),
+	_.int32le('glassY'),
+	// mole
+	_.int32le('moleType'),
+	_.int32le('moleScale'),
+	_.int32le('moleX'),
+	_.int32le('moleY'),
+	// body
+	_.int32le('height'),
+	_.int32le('build'),
+	// personal
+	_.char16le('name', 22),
+	_.char16le('creator', 22),
+	_.int32le('gender'),
+	_.int32le('birthMonth'),
+	_.int32le('birthDay'),
+	_.int32le('favoriteColor'),
+	_.uint8('favorite'),
+	_.uint8('copyable'),
+	_.uint8('ngWord'),
+	_.uint8('localonly'),
+	_.int32le('regionMove'),
+	_.int32le('fontRegion'),
+	_.int32le('roomIndex'),
+	_.int32le('positionInRoom'),
+	_.int32le('birthPlatform'),
+	// other
+	_.uint8('createID', 10),
+	_.uint16le('padding_0'),
+	_.int32le('authorType'),
+	_.uint8('authorID', 8) // stub
+]);
+
+/**
+ * Size of FFLStoreData, a structure not included currently.
+ * @public
+ */
+/** sizeof(FFLStoreData) */
+export const FFLStoreData_size = 96;
+
+// ---------------------- Common Color Mask Definitions ----------------------
+
+/** @package */
+export const commonColorEnableMask = (1 << 31);
+
+/**
+ * Applies (unofficial) mask: FFLI_NN_MII_COMMON_COLOR_ENABLE_MASK
+ * to a common color index to indicate to FFL which color table it should use.
+ * @param {number} color - The color index to flag.
+ * @returns {number} The flagged color index to use in FFLiCharinfo.
+ */
+export const commonColorMask = (color: number): number => color | commonColorEnableMask;
+
+/**
+ * Removes (unofficial) mask: FFLI_NN_MII_COMMON_COLOR_ENABLE_MASK
+ * to a common color index to reveal the original common color index.
+ * @param {number} color - The flagged color index.
+ * @returns {number} The original color index before flagging.
+ */
+export const commonColorUnmask = (color: number): number => (color & ~commonColorEnableMask) === 0
+// Only unmask color if the mask is enabled.
+	? color
+	: color & ~commonColorEnableMask;
+
+// --------------------- Begin FFLiCharModel Definitions ---------------------
+
+export enum facelinePartType {
+	/** Wrinkle */
+	Line = 0,
+	Make = 1,
+	Beard = 2,
+	Count = 3
+};
+
+/** @type {import('./struct-fu').StructInstance<Array<FFLDrawParam>>} */
+export const FFLiFacelineTextureTempObject = _.struct([
+	_.struct([_uintptr(''), FFLDrawParam], facelinePartType.Count),
+	_uintptr('_', 2) // stub
+]);
+
+export enum maskPartType {
+	EyeR = 0,
+	EyeL = 1,
+	EyebrowR = 2,
+	EyebrowL = 3,
+	Mouth = 4,
+	MustacheR = 5,
+	MustacheL = 6,
+	Mole = 7,
+	/** Alpha clear. Can be skipped. */
+	Fill = 8,
+	End = 8
+};
+
+/** @type {import('./struct-fu').StructInstance<Array<FFLDrawParam>>} */
+export const FFLiRawMaskDrawParam = _.struct([FFLDrawParam], maskPartType.End);
+
+/**
+ * @typedef {Object} FFLiMaskTexturesTempObject
+ * @property {Array<number>} pRawMaskDrawParam
+ */
+/** @type {import('./struct-fu').StructInstance<FFLiMaskTexturesTempObject>} */
+export const FFLiMaskTexturesTempObject = _.struct([
+	_.byte(0x154),
+	_uintptr('pRawMaskDrawParam', FFLExpression.MAX),
+	_.byte(0x388 - 620) // stub
+]);
+
+/**
+ * @typedef {Object} FFLiTextureTempObject
+ * @property {FFLiMaskTexturesTempObject} maskTextures
+ * @property {Array<FFLDrawParam>} facelineTexture
+ */
+/** @type {import('./struct-fu').StructInstance<FFLiTextureTempObject>} */
+export const FFLiTextureTempObject = _.struct([
+	_.struct('maskTextures', [FFLiMaskTexturesTempObject]),
+	_.struct('facelineTexture', [FFLiFacelineTextureTempObject])
+]);
+
+/** @package */
+export const FFL_RESOLUTION_MASK = 0x3fffffff;
+
+/**
+ * @typedef {Object} FFLCharModelDesc
+ * @property {number} resolution - Texture resolution for faceline/mask. It's recommended to only use powers of two.
+ * @property {Uint32Array} allExpressionFlag - Expression flag, created by {@link makeExpressionFlag}
+ * @property {FFLModelFlag} modelFlag
+ * @property {FFLResourceType} resourceType
+ */
+/** @type {import('./struct-fu').StructInstance<FFLCharModelDesc>} */
+export const FFLCharModelDesc = _.struct([
+	_.uint32le('resolution'),
+	_.uint32le('allExpressionFlag', 3),
+	_.uint32le('modelFlag'),
+	_.uint32le('resourceType')
+]);
+/**
+ * Static default for FFLCharModelDesc.
+ * @type {FFLCharModelDesc}
+ * @readonly
+ * @public
+ */
+export const FFLCharModelDescDefault = {
+	/** Typical default. */
+	resolution: 512,
+	/** Normal expression. */
+	allExpressionFlag: new Uint32Array([1, 0, 0]),
+	modelFlag: FFLModelFlag.NORMAL,
+	/** Default resource type. */
+	resourceType: FFLResourceType.HIGH
+};
+
+/** @typedef {FFLCharModelDesc|Array<FFLExpression>|FFLExpression|Uint32Array|null} CharModelDescOrExpressionFlag */
+
+/**
+ * @typedef {Object<string, FFLVec3>} FFLPartsTransform
+ * @property {FFLVec3} hatTranslate
+ * @property {FFLVec3} headFrontRotate
+ * @property {FFLVec3} headFrontTranslate
+ * @property {FFLVec3} headSideRotate
+ * @property {FFLVec3} headSideTranslate
+ * @property {FFLVec3} headTopRotate
+ * @property {FFLVec3} headTopTranslate
+ */
+/** @type {import('./struct-fu').StructInstance<FFLPartsTransform>} */
+export const FFLPartsTransform = _.struct([
+	_.struct('hatTranslate', [FFLVec3]),
+	_.struct('headFrontRotate', [FFLVec3]),
+	_.struct('headFrontTranslate', [FFLVec3]),
+	_.struct('headSideRotate', [FFLVec3]),
+	_.struct('headSideTranslate', [FFLVec3]),
+	_.struct('headTopRotate', [FFLVec3]),
+	_.struct('headTopTranslate', [FFLVec3])
+]);
+/**
+ * PartsTransform with THREE.Vector3 type.
+ * @typedef {Object<string, import('three').Vector3>} PartsTransform
+ * @property {import('three').Vector3} hatTranslate
+ * @property {import('three').Vector3} headFrontRotate
+ * @property {import('three').Vector3} headFrontTranslate
+ * @property {import('three').Vector3} headSideRotate
+ * @property {import('three').Vector3} headSideTranslate
+ * @property {import('three').Vector3} headTopRotate
+ * @property {import('three').Vector3} headTopTranslate
+ */
+
+/**
+ * Internal representation within FFL for the created CharModel.
+ * @typedef {Object} FFLiCharModel
+ * @property {FFLiCharInfo} charInfo
+ * @property {FFLCharModelDesc} charModelDesc
+ * @property {FFLExpression} expression
+ * @property {number} pTextureTempObject
+ * @property {Array<FFLDrawParam>} drawParam
+ * @property {Array<number>} pMaskRenderTextures
+ * @property {FFLPartsTransform} partsTransform
+ */
+/** @type {import('./struct-fu').StructInstance<FFLiCharModel>} */
+export const FFLiCharModel = _.struct([
+	_.struct('charInfo', [FFLiCharInfo]),
+	_.struct('charModelDesc', [FFLCharModelDesc]),
+	_.uint32le('expression'), // enum FFLExpression
+	_uintptr('pTextureTempObject'), // stub
+	_.struct('drawParam', [FFLDrawParam], FFLiShapeType.MAX),
+	_uintptr('pShapeData', FFLiShapeType.MAX),
+	_uintptr('facelineRenderTexture', 4), // stub
+	_uintptr('pCapGlassNoselineTextures', 3),
+	_uintptr('pMaskRenderTextures', FFLExpression.MAX),
+	_.byte('beardHairFaceCenterPos', 0x18 * 3), // [FFLVec3], 3
+	_.struct('partsTransform', [FFLPartsTransform]),
+	_.uint32le('modelType'), // enum FFLModelType
+	_.byte(0x18 * 3) // FFLBoundingBox[FFL_MODEL_TYPE_MAX = 3]
+]);
+
+export enum FFLDataSource {
+	OFFICIAL = 0,
+	DEFAULT = 1,
+	MIDDLE_DB = 2,
+	STORE_DATA_OFFICIAL = 3,
+	STORE_DATA = 4,
+	BUFFER = 5,
+	DIRECT_POINTER = 6
+};
+
+/**
+ * @typedef {Object} FFLCharModelSource
+ * @property {FFLDataSource} dataSource
+ * @property {number} pBuffer
+ * @property {number} index - Only for default, official, MiddleDB; unneeded for raw data
+ */
+/** @type {import('./struct-fu').StructInstance<FFLCharModelSource>} */
+export const FFLCharModelSource = _.struct([
+	_.uint32le('dataSource'),
+	_uintptr('pBuffer'),
+	_.uint16le('index')
+]);
+
+// The enums below are only for FFLiGetRandomCharInfo.
+// Hence, why each one has a value called ALL.
+
+export enum FFLGender {
+	MALE = 0,
+	FEMALE = 1,
+	ALL = 2
+};
+
+export enum FFLAge {
+	CHILD = 0,
+	ADULT = 1,
+	ELDER = 2,
+	ALL = 3
+};
+
+export enum FFLRace {
+	BLACK = 0,
+	WHITE = 1,
+	ASIAN = 2,
+	ALL = 3
+};
+
+/**
+ * @typedef {Object} FFLResourceDesc
+ * @property {Array<number>} pData
+ * @property {Array<number>} size
+ */
+/** @type {import('./struct-fu').StructInstance<FFLResourceDesc>} */
+export const FFLResourceDesc = _.struct([
+	_uintptr('pData', FFLResourceType.MAX),
+	_.uint32le('size', FFLResourceType.MAX)
+]);
+
+// // ---------------------------------------------------------------------
+// //  Texture Management
+// // ---------------------------------------------------------------------
+
+// ------------------------- Texture Related Structs -------------------------
+export enum FFLTextureFormat {
+	R8_UNORM = 0,
+	R8_G8_UNORM = 1,
+	R8_G8_B8_A8_UNORM = 2,
+	MAX = 3
+};
+
+/**
+ * @typedef {Object} FFLTextureInfo
+ * @property {number} width
+ * @property {number} height
+ * @property {number} mipCount
+ * @property {FFLTextureFormat} format
+ * @property {number} imageSize
+ * @property {number} imagePtr
+ * @property {number} mipSize
+ * @property {number} mipPtr
+ * @property {Array<number>} mipLevelOffset
+ */
+/** @type {import('./struct-fu').StructInstance<FFLTextureInfo>} */
+export const FFLTextureInfo = _.struct([
+	_.uint16le('width'),
+	_.uint16le('height'),
+	_.uint8('mipCount'),
+	_.uint8('format'),
+	_.uint8('isGX2Tiled'),
+	_.byte('_padding', 1),
+	_.uint32le('imageSize'),
+	_uintptr('imagePtr'),
+	_.uint32le('mipSize'),
+	_uintptr('mipPtr'),
+	_.uint32le('mipLevelOffset', 13)
+]);
+
+export const FFLTextureCallback = _.struct([
+	_uintptr('pObj'),
+	_.uint8('useOriginalTileMode'),
+	_.byte('_padding', 3), // alignment
+	_uintptr('pCreateFunc'),
+	_uintptr('pDeleteFunc')
+]);

--- a/src/StudioCharInfo.ts
+++ b/src/StudioCharInfo.ts
@@ -1,0 +1,259 @@
+/**
+ * @typedef {Object} StudioCharInfo
+ * @property {number} beardColor
+ * @property {number} beardType
+ * @property {number} build
+ * @property {number} eyeAspect
+ * @property {number} eyeColor
+ * @property {number} eyeRotate
+ * @property {number} eyeScale
+ * @property {number} eyeType
+ * @property {number} eyeX
+ * @property {number} eyeY
+ * @property {number} eyebrowAspect
+ * @property {number} eyebrowColor
+ * @property {number} eyebrowRotate
+ * @property {number} eyebrowScale
+ * @property {number} eyebrowType
+ * @property {number} eyebrowX
+ * @property {number} eyebrowY
+ * @property {number} facelineColor
+ * @property {number} facelineMake
+ * @property {number} facelineType
+ * @property {number} facelineWrinkle
+ * @property {number} favoriteColor
+ * @property {number} gender
+ * @property {number} glassColor
+ * @property {number} glassScale
+ * @property {number} glassType
+ * @property {number} glassY
+ * @property {number} hairColor
+ * @property {number} hairFlip
+ * @property {number} hairType
+ * @property {number} height
+ * @property {number} moleScale
+ * @property {number} moleType
+ * @property {number} moleX
+ * @property {number} moleY
+ * @property {number} mouthAspect
+ * @property {number} mouthColor
+ * @property {number} mouthScale
+ * @property {number} mouthType
+ * @property {number} mouthY
+ * @property {number} mustacheScale
+ * @property {number} mustacheType
+ * @property {number} mustacheY
+ * @property {number} noseScale
+ * @property {number} noseType
+ * @property {number} noseY
+ */
+
+import { commonColorMask, commonColorUnmask, FFLiCharInfo } from "./StructFFLiCharModel";
+
+/**
+ * Structure representing data from the studio.mii.nintendo.com site and API.
+ * @type {import('./struct-fu').StructInstance<StudioCharInfo>}
+ */
+export const StudioCharInfo = _.struct([
+	// Fields are named according to nn::mii::CharInfo.
+	_.uint8('beardColor'),
+	_.uint8('beardType'),
+	_.uint8('build'),
+	_.uint8('eyeAspect'),
+	_.uint8('eyeColor'),
+	_.uint8('eyeRotate'),
+	_.uint8('eyeScale'),
+	_.uint8('eyeType'),
+	_.uint8('eyeX'),
+	_.uint8('eyeY'),
+	_.uint8('eyebrowAspect'),
+	_.uint8('eyebrowColor'),
+	_.uint8('eyebrowRotate'),
+	_.uint8('eyebrowScale'),
+	_.uint8('eyebrowType'),
+	_.uint8('eyebrowX'),
+	_.uint8('eyebrowY'),
+	_.uint8('facelineColor'),
+	_.uint8('facelineMake'),
+	_.uint8('facelineType'),
+	_.uint8('facelineWrinkle'),
+	_.uint8('favoriteColor'),
+	_.uint8('gender'),
+	_.uint8('glassColor'),
+	_.uint8('glassScale'),
+	_.uint8('glassType'),
+	_.uint8('glassY'),
+	_.uint8('hairColor'),
+	_.uint8('hairFlip'),
+	_.uint8('hairType'),
+	_.uint8('height'),
+	_.uint8('moleScale'),
+	_.uint8('moleType'),
+	_.uint8('moleX'),
+	_.uint8('moleY'),
+	_.uint8('mouthAspect'),
+	_.uint8('mouthColor'),
+	_.uint8('mouthScale'),
+	_.uint8('mouthType'),
+	_.uint8('mouthY'),
+	_.uint8('mustacheScale'),
+	_.uint8('mustacheType'),
+	_.uint8('mustacheY'),
+	_.uint8('noseScale'),
+	_.uint8('noseType'),
+	_.uint8('noseY')
+]);
+
+// ----------------- convertStudioCharInfoToFFLiCharInfo(src) -----------------
+/**
+ * Creates an FFLiCharInfo object from StudioCharInfo.
+ * @param {StudioCharInfo} src - The StudioCharInfo instance.
+ * @returns {FFLiCharInfo} The FFLiCharInfo output.
+ */
+export function convertStudioCharInfoToFFLiCharInfo(src: ReturnType<typeof StudioCharInfo.unpack>): ReturnType<typeof FFLiCharInfo.unpack> {
+	return {
+		miiVersion: 0,
+		faceType: src.facelineType,
+		faceColor: src.facelineColor,
+		faceTex: src.facelineWrinkle,
+		faceMake: src.facelineMake,
+		hairType: src.hairType,
+		hairColor: commonColorMask(src.hairColor),
+		hairFlip: src.hairFlip,
+		eyeType: src.eyeType,
+		eyeColor: commonColorMask(src.eyeColor),
+		eyeScale: src.eyeScale,
+		eyeAspect: src.eyeAspect,
+		eyeRotate: src.eyeRotate,
+		eyeX: src.eyeX,
+		eyeY: src.eyeY,
+		eyebrowType: src.eyebrowType,
+		eyebrowColor: commonColorMask(src.eyebrowColor),
+		eyebrowScale: src.eyebrowScale,
+		eyebrowAspect: src.eyebrowAspect,
+		eyebrowRotate: src.eyebrowRotate,
+		eyebrowX: src.eyebrowX,
+		eyebrowY: src.eyebrowY,
+		noseType: src.noseType,
+		noseScale: src.noseScale,
+		noseY: src.noseY,
+		mouthType: src.mouthType,
+		mouthColor: commonColorMask(src.mouthColor),
+		mouthScale: src.mouthScale,
+		mouthAspect: src.mouthAspect,
+		mouthY: src.mouthY,
+		beardMustache: src.mustacheType,
+		beardType: src.beardType,
+		beardColor: commonColorMask(src.beardColor),
+		beardScale: src.mustacheScale,
+		beardY: src.mustacheY,
+		glassType: src.glassType,
+		glassColor: commonColorMask(src.glassColor),
+		glassScale: src.glassScale,
+		glassY: src.glassY,
+		moleType: src.moleType,
+		moleScale: src.moleScale,
+		moleX: src.moleX,
+		moleY: src.moleY,
+		height: src.height,
+		build: src.build,
+		name: '',
+		creator: '',
+		gender: src.gender,
+		birthMonth: 0,
+		birthDay: 0,
+		favoriteColor: src.favoriteColor,
+		favorite: 0,
+		copyable: 0,
+		ngWord: 0,
+		localonly: 0,
+		regionMove: 0,
+		fontRegion: 0,
+		roomIndex: 0,
+		positionInRoom: 0,
+		birthPlatform: 3, // FFL_BIRTH_PLATFORM_CTR
+		createID: new Array(10),
+		padding_0: 0,
+		authorType: 0,
+		authorID: new Array(8)
+	};
+}
+
+// --------------------- studioURLObfuscationDecode(data) ---------------------
+/**
+ * @param {Uint8Array} data - Obfuscated Studio URL data.
+ * @returns {Uint8Array} Decoded Uint8Array representing CharInfoStudio.
+ */
+export function studioURLObfuscationDecode(data: Uint8Array): Uint8Array {
+	const decodedData = new Uint8Array(data);
+	const random = decodedData[0];
+	let previous = random;
+
+	for (let i = 1; i < 48; i++) {
+		const encodedByte = decodedData[i];
+		const original = (encodedByte - 7 + 256) % 256;
+		decodedData[i - 1] = original ^ previous;
+		previous = encodedByte;
+	}
+
+	return decodedData.slice(0, StudioCharInfo.size); // Clamp to StudioCharInfo.size
+}
+
+// ----------------- convertFFLiCharInfoToStudioCharInfo(src) -----------------
+/**
+ * Creates a StudioCharInfo object from FFLiCharInfo.
+ * @param {FFLiCharInfo} src - The FFLiCharInfo instance.
+ * @returns {StudioCharInfo} The StudioCharInfo output.
+ * @todo TODO: Currently does NOT convert color indices
+ * to CommonColor indices (ToVer3... etc)
+ */
+export function convertFFLiCharInfoToStudioCharInfo(src: ReturnType<typeof FFLiCharInfo.unpack>): ReturnType<typeof StudioCharInfo.unpack> {
+	return {
+		beardColor: commonColorUnmask(src.beardColor),
+		beardType: src.beardType,
+		build: src.build,
+		eyeAspect: src.eyeAspect,
+		eyeColor: commonColorUnmask(src.eyeColor),
+		eyeRotate: src.eyeRotate,
+		eyeScale: src.eyeScale,
+		eyeType: src.eyeType,
+		eyeX: src.eyeX,
+		eyeY: src.eyeY,
+		eyebrowAspect: src.eyebrowAspect,
+		eyebrowColor: commonColorUnmask(src.eyebrowColor),
+		eyebrowRotate: src.eyebrowRotate,
+		eyebrowScale: src.eyebrowScale,
+		eyebrowType: src.eyebrowType,
+		eyebrowX: src.eyebrowX,
+		eyebrowY: src.eyebrowY,
+		facelineColor: src.faceColor,
+		facelineMake: src.faceMake,
+		facelineType: src.faceType,
+		facelineWrinkle: src.faceTex,
+		favoriteColor: src.favoriteColor,
+		gender: src.gender,
+		glassColor: commonColorUnmask(src.glassColor),
+		glassScale: src.glassScale,
+		glassType: src.glassType,
+		glassY: src.glassY,
+		hairColor: commonColorUnmask(src.hairColor),
+		hairFlip: src.hairFlip,
+		hairType: src.hairType,
+		height: src.height,
+		moleScale: src.moleScale,
+		moleType: src.moleType,
+		moleX: src.moleX,
+		moleY: src.moleY,
+		mouthAspect: src.mouthAspect,
+		mouthColor: commonColorUnmask(src.mouthColor),
+		mouthScale: src.mouthScale,
+		mouthType: src.mouthType,
+		mouthY: src.mouthY,
+		mustacheScale: src.beardScale,
+		mustacheType: src.beardMustache,
+		mustacheY: src.beardY,
+		noseScale: src.noseScale,
+		noseType: src.noseType,
+		noseY: src.noseY
+	};
+}

--- a/src/StudioCharInfo.ts
+++ b/src/StudioCharInfo.ts
@@ -1,3 +1,5 @@
+import * as _ from '../struct-fu.js';
+
 /**
  * @typedef {Object} StudioCharInfo
  * @property {number} beardColor
@@ -48,7 +50,7 @@
  * @property {number} noseY
  */
 
-import { commonColorMask, commonColorUnmask, FFLiCharInfo } from "./StructFFLiCharModel";
+import { commonColorMask, commonColorUnmask, FFLiCharInfo } from "@/StructFFLiCharModel";
 
 /**
  * Structure representing data from the studio.mii.nintendo.com site and API.

--- a/src/TextureManager.ts
+++ b/src/TextureManager.ts
@@ -1,8 +1,8 @@
 import * as THREE from 'three';
-import Module from "./Module";
-import { FFLTextureCallback, FFLTextureFormat, FFLTextureInfo } from './StructFFLiCharModel';
-import { _isWebGPU } from './RenderTargetUtils';
-import Renderer from './renderer';
+import { Module } from "@/Module";
+import { FFLTextureCallback, FFLTextureFormat, FFLTextureInfo } from '@/StructFFLiCharModel';
+import { _isWebGPU } from '@/RenderTargetUtils';
+import Renderer from '@/renderer';
 
 /**
  * Manages THREE.Texture objects created via FFL.

--- a/src/TextureManager.ts
+++ b/src/TextureManager.ts
@@ -1,0 +1,348 @@
+import * as THREE from 'three';
+import Module from "./Module";
+import { FFLTextureCallback, FFLTextureFormat, FFLTextureInfo } from './StructFFLiCharModel';
+import { _isWebGPU } from './RenderTargetUtils';
+import Renderer from './renderer';
+
+/**
+ * Manages THREE.Texture objects created via FFL.
+ * Must be instantiated after FFL is fully initialized.
+ * @package
+ */
+export default class TextureManager {
+	private _module: Module;
+	private _textures = new Map<number, THREE.Texture>();
+	private _createCallback?: number;
+	private _deleteCallback?: number;
+
+	public _textureCallbackPtr = 0;
+
+	/**
+	 * Controls whether or not the TextureManager
+	 * will log creations and deletions of textures
+	 * in order to better track memory allocations.
+	 */
+	public logging = false;
+
+	/**
+	 * Global that controls if texture creation should be changed
+	 * to account for WebGL 1.0. (Shapes should be fine)
+	 */
+	static isWebGL1 = false;
+
+	/**
+	 * Constructs the TextureManager. This MUST be created after initializing FFL.
+	 * @param {Module} module - The Emscripten module.
+	 * @param {boolean} [setToFFLGlobal] - Whether or not to call FFLSetTextureCallback on the constructed callback.
+	 */
+	constructor(module: Module, setToFFLGlobal = false) {
+		this._module = module;
+
+		// Create and set texture callback instance.
+		this._setTextureCallback();
+		if (setToFFLGlobal) {
+			// Set texture callback globally within FFL if chosen.
+			module._FFLSetTextureCallback(this._textureCallbackPtr);
+		}
+	}
+
+	/**
+	 * Creates and allocates an {@link FFLTextureCallback} instance from callback function pointers.
+	 * @param {Module} module - The Emscripten module.
+	 * @param {number} createCallback - Function pointer for the create callback.
+	 * @param {number} deleteCallback - Function pointer for the delete callback.
+	 * @returns {number} Pointer to the {@link FFLTextureCallback}.
+	 * Note that you MUST free this after using it (done in {@link TextureManager.disposeCallback}).
+	 */
+	private static _allocateTextureCallback(module: Module, createCallback: number, deleteCallback: number): number {
+		const ptr = module._malloc(FFLTextureCallback.size);
+		const textureCallback = {
+			pObj: 0,
+			useOriginalTileMode: false,
+			_padding: [0, 0, 0],
+			pCreateFunc: createCallback,
+			pDeleteFunc: deleteCallback
+		};
+		const packed = FFLTextureCallback.pack(textureCallback);
+		module.HEAPU8.set(packed, ptr);
+		return ptr;
+	}
+
+	/**
+	 * Creates the create/delete functions in Emscripten and allocates and sets
+	 * the {@link FFLTextureCallback} object as {@link TextureManager._textureCallbackPtr}.
+	 * @param {boolean} addDeleteCallback - Whether or not to bind the delete function to the texture callback.
+	 */
+	public _setTextureCallback(addDeleteCallback = false): void {
+		const mod = this._module;
+
+		this._createCallback = mod.addFunction(this._textureCreateFunc.bind(this), 'vppp');
+
+		if (addDeleteCallback) {
+			this._deleteCallback = mod.addFunction(this._textureDeleteFunc.bind(this), 'vpp');
+		}
+
+		this._textureCallbackPtr = TextureManager._allocateTextureCallback(mod,
+			this._createCallback, this._deleteCallback ? this._deleteCallback : 0);
+	}
+
+	/**
+	 * @param {number} format - Enum value for FFLTextureFormat.
+	 * @returns {import('three').PixelFormat} Three.js texture format constant.
+	 * Note that this function won't work on WebGL1Renderer in Three.js r137-r162
+	 * since R and RG textures need to use Luminance(Alpha)Format
+	 * (you'd somehow need to detect which renderer is used)
+	 */
+	private _getTextureFormat(format: FFLTextureFormat): THREE.PixelFormat {
+		// Map FFLTextureFormat to Three.js texture formats.
+
+		// THREE.RGFormat did not work for me on Three.js r136/older.
+		const useGLES2Formats = Number(THREE.REVISION) <= 136 || TextureManager.isWebGL1;
+		const r8 = useGLES2Formats
+			// eslint-disable-next-line import/namespace -- deprecated, maybe deleted
+			? THREE.LuminanceFormat
+			: THREE.RedFormat;
+		const r8g8 = useGLES2Formats
+		// NOTE: Using THREE.LuminanceAlphaFormat before it
+		// was removed on WebGL 1.0/2.0 causes the texture
+		// to be converted to RGBA resulting in two issues.
+		//     - There is a black outline around glasses
+		//     - For glasses that have an inner color, the color is wrongly applied to the frames as well.
+			// eslint-disable-next-line import/namespace -- deprecated, maybe deleted
+			? THREE.LuminanceAlphaFormat
+			: THREE.RGFormat;
+
+		const textureFormatToThreeFormat: Partial<Record<FFLTextureFormat, THREE.PixelFormat>> = {
+			[FFLTextureFormat.R8_UNORM]: r8,
+			[FFLTextureFormat.R8_G8_UNORM]: r8g8,
+			[FFLTextureFormat.R8_G8_B8_A8_UNORM]: THREE.RGBAFormat
+		};
+
+		// Determine the data format from the table.
+		const dataFormat = textureFormatToThreeFormat[format];
+		console.assert(dataFormat !== undefined, `_textureCreateFunc: Unexpected FFLTextureFormat value: ${format}`);
+		return dataFormat!;
+	}
+
+	/**
+	 * @param {number} _ - Originally pObj, unused here.
+	 * @param {number} textureInfoPtr - Pointer to {@link FFLTextureInfo}.
+	 * @param {number} texturePtrPtr - Pointer to the texture handle (pTexture2D).
+	 */
+	private _textureCreateFunc(_: never, textureInfoPtr: number, texturePtrPtr: number): void {
+		const u8 = this._module.HEAPU8.subarray(textureInfoPtr,
+			textureInfoPtr + FFLTextureInfo.size);
+		const textureInfo = FFLTextureInfo.unpack(u8);
+		if (this.logging) {
+			console.debug(`_textureCreateFunc: width=${textureInfo.width}, height=${textureInfo.height}, format=${textureInfo.format}, imageSize=${textureInfo.imageSize}, mipCount=${textureInfo.mipCount}`);
+		}
+
+		/** Resolve THREE.PixelFormat. */
+		const format = this._getTextureFormat(textureInfo.format);
+		// Copy image data from HEAPU8 via slice. This is base level/mip level 0.
+		const imageData = this._module.HEAPU8.slice(textureInfo.imagePtr,
+			textureInfo.imagePtr + textureInfo.imageSize);
+
+		/**
+		 * Determine whether mipmaps can be used at all.
+		 * Implemented in Three.js r137 and only works properly on r138.
+		 *
+		 * This is also disabled for WebGL 1.0, since there are some NPOT textures.
+		 * Those aren't supposed to have mipmaps e.g., glass, but I found that
+		 * while in GLES2, some textures that didn't wrap could have mips with
+		 * NPOT, this didn't work in WebGL 1.0.
+		 */
+		const canUseMipmaps = Number(THREE.REVISION) >= 138 && !TextureManager.isWebGL1;
+		// Actually use mipmaps if the mip count is over 1.
+		const useMipmaps = textureInfo.mipCount > 1 && canUseMipmaps;
+
+		// Create new THREE.Texture with the specified format.
+		const texture = new THREE.DataTexture(useMipmaps ? null : imageData,
+			textureInfo.width, textureInfo.height, format, THREE.UnsignedByteType);
+
+		texture.magFilter = THREE.LinearFilter;
+		// texture.generateMipmaps = true; // not necessary at higher resolutions
+		texture.minFilter = THREE.LinearFilter;
+
+		if (useMipmaps) {
+			// Add base texture.
+			texture.mipmaps = [{
+				data: imageData,
+				width: textureInfo.width,
+				height: textureInfo.height
+			}];
+			// Enable filtering option for mipmap and add levels.
+			texture.minFilter = THREE.LinearMipmapLinearFilter;
+			texture.generateMipmaps = false;
+			this._addMipmaps(texture, textureInfo);
+		}
+
+		texture.needsUpdate = true;
+		this.set(texture.id, texture);
+		this._module.HEAPU32[texturePtrPtr / 4] = texture.id;
+	}
+
+	/**
+	 * @param {import('three').Texture} texture - Texture to upload mipmaps into.
+	 * @param {FFLTextureInfo} textureInfo - FFLTextureInfo object representing this texture.
+	 */
+	private _addMipmaps(texture: THREE.Texture, textureInfo: ReturnType<typeof FFLTextureInfo.unpack>): void {
+		// Make sure mipPtr is not null.
+		console.assert(textureInfo.mipPtr, '_addMipmaps: mipPtr is null, so the caller incorrectly assumed this texture has mipmaps');
+
+		// Iterate through mip levels starting from 1 (base level is mip level 0).
+		for (let mipLevel = 1; mipLevel < textureInfo.mipCount; mipLevel++) {
+			// Calculate the offset for the current mip level.
+			const mipOffset = textureInfo.mipLevelOffset[mipLevel - 1];
+
+			// Calculate dimensions of the current mip level.
+			const mipWidth = Math.max(1, textureInfo.width >> mipLevel);
+			const mipHeight = Math.max(1, textureInfo.height >> mipLevel);
+
+			// Get the offset of the next mipmap and calculate end offset.
+			const nextMipOffset = textureInfo.mipLevelOffset[mipLevel] || textureInfo.mipSize;
+			const end = textureInfo.mipPtr + nextMipOffset;
+
+			// Copy the data from the heap.
+			const start = textureInfo.mipPtr + mipOffset;
+			const mipData = this._module.HEAPU8.slice(start, end);
+
+			if (this.logging) {
+				console.debug(`  - Mip ${mipLevel}: ${mipWidth}x${mipHeight}, offset=${mipOffset}, range=${start}-${end}`);
+			}
+			// console.debug(uint8ArrayToBase64(mipData)); // will leak the data
+
+			// Push this mip level data into the texture's mipmaps array.
+			// @ts-ignore - data = "CompressedTextureMipmap & CubeTexture & HTMLCanvasElement"
+			texture.mipmaps.push({
+				data: mipData, // Should still accept Uint8Array.
+				width: mipWidth,
+				height: mipHeight
+			});
+		}
+	}
+
+	/**
+	 * @param {number} _ - Originally pObj, unused here.
+	 * @param {number} texturePtrPtr - Pointer to the texture handle (pTexture2D).
+	 */
+	private _textureDeleteFunc(_: never, texturePtrPtr: number): void {
+		const texId = this._module.HEAPU32[texturePtrPtr / 4];
+		// this.delete(texId);
+		// NOTE: This is effectively no longer used as when
+		// we delete a CharModel instance it deletes
+		// cap/noseline/glass textures before we are
+		// finished with the model itself. It is now only logging
+		const tex = this._textures.get(texId);
+		if (tex && this.logging) {
+			console.debug('Delete texture    ', tex.id);
+		}
+	}
+
+	/**
+	 * @param {number} id - ID assigned to the texture.
+	 * @returns {import('three').Texture|null|undefined} Returns the texture if it is found.
+	 */
+	public get(id: number): THREE.Texture | null | undefined {
+		const texture = this._textures.get(id);
+		if (!texture && this.logging) {
+			console.error('Unknown texture', id);
+		}
+		return texture;
+	}
+
+	/**
+	 * @param {number} id - ID assigned to the texture.
+	 * @param {import('three').Texture} texture - Texture to add.
+	 */
+	public set(id: number, texture: THREE.Texture): void {
+		// Set texture with an override for dispose.
+		const disposeReal = texture.dispose.bind(texture);
+		texture.dispose = () => {
+			// Remove this texture from the map after disposing.
+			disposeReal();
+			this.delete(id); // this = TextureManager
+		};
+
+		this._textures.set(id, texture);
+		// Log is spaced to match delete/deleting/dispose messages.
+		if (this.logging) {
+			console.debug('Adding texture    ', texture.id);
+		}
+	}
+
+	/**
+	 * @param {number} id - ID assigned to the texture.
+	 */
+	public delete(id: number): void {
+		// Get texture from array instead of with get()
+		// because it's okay if it was already deleted.
+		const texture = this._textures.get(id);
+		if (texture) {
+			// This is assuming the texture has already been disposed.
+			(texture as Record<string, any>).source = null;
+			(texture as Record<string, any>).mipmaps = null;
+			if (this.logging) {
+				console.debug('Deleted texture   ', id);
+			}
+			this._textures.delete(id);
+		}
+	}
+
+	/**
+	 * Disposes/frees the {@link FFLTextureCallback} along with
+	 * removing the created Emscripten functions.
+	 */
+	public disposeCallback(): void {
+		// if (!this._module) {
+		// 	return;
+		// }
+		if (this._textureCallbackPtr) {
+			this._module._free(this._textureCallbackPtr);
+			this._textureCallbackPtr = 0;
+		}
+		if (this._deleteCallback) {
+			this._module.removeFunction(this._deleteCallback);
+			this._deleteCallback = 0;
+		}
+		// should always exist?:
+		if (this._createCallback) {
+			this._module.removeFunction(this._createCallback);
+			this._createCallback = 0;
+		}
+		// this._module = null;
+	}
+
+	/**
+	 * Disposes of all textures and frees the {@link FFLTextureCallback}.
+	 */
+	public dispose(): void {
+		// Dispose of all stored textures.
+		this._textures.forEach((tex) => {
+			tex.dispose();
+		});
+
+		// Clear texture map.
+		this._textures.clear();
+		// Free texture callback.
+		this.disposeCallback();
+	}
+}
+
+/** @typedef {import('three/src/renderers/common/Renderer.js', {with:{'resolution-mode':'import'}}).default} Renderer */
+
+/**
+ * Sets the state for whether WebGL 1.0 or WebGPU is being used.
+ * Otherwise, textures will appear wrong when not using WebGL 2.0.
+ * @param {Renderer} renderer - The WebGLRenderer or WebGPURenderer.
+ * @param {Module} module - The module. Must be initialized along with the renderer.
+ */
+export function setRendererState(renderer: Renderer, module: Module): void {
+	console.assert(renderer && module, `setRendererState: The renderer and module must both be valid.`);
+	if ('capabilities' in renderer &&
+		!((renderer.capabilities as THREE.WebGLCapabilities).isWebGL2)) {
+		TextureManager.isWebGL1 = true;
+	} else if (_isWebGPU(renderer)) {
+		module._FFLSetTextureFlipY(false);
+	}
+}

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,214 @@
+/**
+ * Uses FFL decomp enum rather than real FFL enum.
+ * Reference: https://github.com/aboood40091/ffl/blob/master/include/nn/ffl/FFLResult.h
+ */
+export enum FFLResult {
+	OK = 0,
+	ERROR = 1,
+	HDB_EMPTY = 2,
+	FILE_INVALID = 3,
+	MANAGER_NOT_CONSTRUCT = 4,
+	FILE_LOAD_ERROR = 5,
+	//  = 6,
+	FILE_SAVE_ERROR = 7,
+	//  = 8,
+	RES_FS_ERROR = 9,
+	ODB_EMPTY = 10,
+	//  =  11,
+	OUT_OF_MEMORY = 12,
+	//  =  13,
+	//  =  14,
+	//  =  15,
+	//  =  16,
+	UNKNOWN_17 = 17,
+	FS_ERROR = 18,
+	FS_NOT_FOUND = 19,
+	MAX = 20
+};
+
+export enum FFLiShapeType {
+	OPA_BEARD = 0,
+	OPA_FACELINE = 1,
+	OPA_HAIR_NORMAL = 2,
+	OPA_FOREHEAD_NORMAL = 3,
+	XLU_MASK = 4,
+	XLU_NOSELINE = 5,
+	OPA_NOSE = 6,
+	OPA_HAT_NORMAL = 7,
+	XLU_GLASS = 8,
+	OPA_HAIR_CAP = 9,
+	OPA_FOREHEAD_CAP = 10,
+	OPA_HAT_CAP = 11,
+	MAX = 12
+};
+
+export enum FFLAttributeBufferType {
+	POSITION = 0,
+	TEXCOORD = 1,
+	NORMAL = 2,
+	TANGENT = 3,
+	COLOR = 4,
+	MAX = 5
+};
+
+export enum FFLCullMode {
+	NONE = 0,
+	BACK = 1,
+	FRONT = 2,
+	MAX = 3
+};
+
+export enum FFLModulateMode {
+	/** No Texture, Has Color (R) */
+	CONSTANT = 0,
+	/** Has Texture, No Color */
+	TEXTURE_DIRECT = 1,
+	/** Has Texture, Has Color (R + G + B) */
+	RGB_LAYERED = 2,
+	/** Has Texture, Has Color (R) */
+	ALPHA = 3,
+	/** Has Texture, Has Color (R) */
+	LUMINANCE_ALPHA = 4,
+	/** Has Texture, Has Color (R) */
+	ALPHA_OPA = 5
+};
+
+export enum FFLModulateType {
+	SHAPE_FACELINE = 0,
+	SHAPE_BEARD = 1,
+	SHAPE_NOSE = 2,
+	SHAPE_FOREHEAD = 3,
+	SHAPE_HAIR = 4,
+	SHAPE_CAP = 5,
+	SHAPE_MASK = 6,
+	SHAPE_NOSELINE = 7,
+	SHAPE_GLASS = 8,
+	MUSTACHE = 9,
+	MOUTH = 10,
+	EYEBROW = 11,
+	EYE = 12,
+	MOLE = 13,
+	FACE_MAKE = 14,
+	FACE_LINE = 15,
+	FACE_BEARD = 16,
+	FILL = 17,
+	SHAPE_MAX = 9
+};
+
+export enum FFLResourceType {
+	MIDDLE = 0,
+	HIGH = 1,
+	MAX = 2
+};
+
+/**
+ * Reference = https://github.com/ariankordi/ffl/blob/nsmbu-win-port-linux64/include/nn/ffl/FFLExpression.h
+ */
+export enum FFLExpression {
+	NORMAL = 0,
+	SMILE = 1,
+	ANGER = 2,
+	/** Primary name for expression 3. */
+	SORROW = 3,
+	PUZZLED = 3,
+	/** Primary name for expression 4. */
+	SURPRISE = 4,
+	SURPRISED = 4,
+	BLINK = 5,
+	OPEN_MOUTH = 6,
+	/** Primary name for expression 7. */
+	SMILE_OPEN_MOUTH = 7,
+	HAPPY = 7,
+	ANGER_OPEN_MOUTH = 8,
+	SORROW_OPEN_MOUTH = 9,
+	SURPRISE_OPEN_MOUTH = 10,
+	BLINK_OPEN_MOUTH = 11,
+	WINK_LEFT = 12,
+	WINK_RIGHT = 13,
+	WINK_LEFT_OPEN_MOUTH = 14,
+	WINK_RIGHT_OPEN_MOUTH = 15,
+	/** Primary name for expression 16. */
+	LIKE_WINK_LEFT = 16,
+	LIKE = 16,
+	LIKE_WINK_RIGHT = 17,
+	FRUSTRATED = 18,
+
+	// Additional expressions from AFL.
+	// Enum names are completely made up.
+	BORED = 19,
+	BORED_OPEN_MOUTH = 20,
+	SIGH_MOUTH_STRAIGHT = 21,
+	SIGH = 22,
+	DISGUSTED_MOUTH_STRAIGHT = 23,
+	DISGUSTED = 24,
+	LOVE = 25,
+	LOVE_OPEN_MOUTH = 26,
+	DETERMINED_MOUTH_STRAIGHT = 27,
+	DETERMINED = 28,
+	CRY_MOUTH_STRAIGHT = 29,
+	CRY = 30,
+	BIG_SMILE_MOUTH_STRAIGHT = 31,
+	BIG_SMILE = 32,
+	CHEEKY = 33,
+	CHEEKY_DUPLICATE = 34,
+	JOJO_EYES_FUNNY_MOUTH = 35,
+	JOJO_EYES_FUNNY_MOUTH_OPEN = 36,
+	SMUG = 37,
+	SMUG_OPEN_MOUTH = 38,
+	RESOLVE = 39,
+	RESOLVE_OPEN_MOUTH = 40,
+	UNBELIEVABLE = 41,
+	UNBELIEVABLE_DUPLICATE = 42,
+	CUNNING = 43,
+	CUNNING_DUPLICATE = 44,
+	RASPBERRY = 45,
+	RASPBERRY_DUPLICATE = 46,
+	INNOCENT = 47,
+	INNOCENT_DUPLICATE = 48,
+	CAT = 49,
+	CAT_DUPLICATE = 50,
+	DOG = 51,
+	DOG_DUPLICATE = 52,
+	TASTY = 53,
+	TASTY_DUPLICATE = 54,
+	MONEY_MOUTH_STRAIGHT = 55,
+	MONEY = 56,
+	SPIRAL_MOUTH_STRAIGHT = 57,
+	CONFUSED = 58,
+	CHEERFUL_MOUTH_STRAIGHT = 59,
+	CHEERFUL = 60,
+	BLANK_61 = 61,
+	BLANK_62 = 62,
+	GRUMBLE_MOUTH_STRAIGHT = 63,
+	GRUMBLE = 64,
+	MOVED_MOUTH_STRAIGHT = 65,
+	MOVED = 66,
+	SINGING_MOUTH_SMALL = 67,
+	SINGING = 68,
+	STUNNED = 69,
+
+	MAX = 70
+};
+
+/**
+ * Model flags modify how the head model is created. These are
+ * used in the `modelFlag` property of {@link FFLCharModelDesc}.
+ */
+export enum FFLModelFlag {
+	/** Default model setting. */
+	NORMAL = 1 << 0,
+	/** Uses a variant of hair designed for hats. */
+	HAT = 1 << 1,
+	/** Discards hair from the model, used for helmets and similar headwear. */
+	FACE_ONLY = 1 << 2,
+	/** Limits Z depth on the nose, useful for helmets and similar headwear. */
+	FLATTEN_NOSE = 1 << 3,
+	/** Enables the model's expression flag to use expressions beyond 32. */
+	NEW_EXPRESSIONS = 1 << 4,
+	/**
+	 * This flag only generates new textures when initializing a CharModel
+	 * but does not initialize shapes.
+	 * **Note:** This means you cannot use DrawOpa/Xlu when this is set.
+	 */
+	NEW_MASK_ONLY = 1 << 5
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,51 @@
+export * from '@/Body';
+
+export * from '@/CharInfo';
+
+export { default as CharModel } from '@/CharModel';
+export type * from '@/CharModel';
+
+export * from '@/CharModelCreation';
+
+export { default as CharModelDescOrExpressionFlag } from '@/CharModelDescOrExpressionFlag';
+
+export * from '@/CharModelTextures';
+
+export * from '@/CodecUtilities';
+
+export * from '@/DrawParam';
+
+export * from '@/enums';
+
+export * from '@/Exceptions';
+
+export * from '@/ExportTexture';
+
+export * from '@/GeometryConversion';
+
+export * from '@/Init';
+
+export type { default as FFLShaderMaterialParameters } from '@/materials/FFLShaderMaterialParameters';
+
+export type { default as SampleShaderMaterialColorInfo } from '@/materials/SampleShaderMaterialColorInfo';
+
+export { default as TextureShaderMaterial } from '@/materials/TextureShaderMaterial';
+
+export * from '@/ModelIcon';
+
+export type * from '@/Module';
+
+export * from '@/ModulateTextureConversion';
+
+export { default as Renderer } from '@/renderer';
+
+export * from '@/RenderTargetUtils';
+
+export * from '@/StructFFLiCharModel';
+
+export * from '@/StudioCharInfo';
+
+export * from '@/structs';
+
+export { default as TextureManager } from '@/TextureManager';
+export * from '@/TextureManager';

--- a/src/materials/FFLShaderMaterialParameters.ts
+++ b/src/materials/FFLShaderMaterialParameters.ts
@@ -1,4 +1,4 @@
-import { FFLModulateMode, FFLModulateType } from '../enums';
+import { FFLModulateMode, FFLModulateType } from '@/enums';
 import type { Color, Vector3, Texture } from 'three';
 
 type FFLShaderMaterialParameters = {

--- a/src/materials/FFLShaderMaterialParameters.ts
+++ b/src/materials/FFLShaderMaterialParameters.ts
@@ -1,0 +1,25 @@
+import { FFLModulateMode, FFLModulateType } from '../enums';
+import type { Color, Vector3, Texture } from 'three';
+
+type FFLShaderMaterialParameters = {
+	/** Modulate mode. */
+	modulateMode?: FFLModulateMode;
+	/** Modulate type. */
+	modulateType?: FFLModulateType;
+	/**
+	 * Constant color assigned to u_const1/2/3 depending on single or array.
+	 */
+	color?: Color | Array<Color>;
+	/** Enable lighting. Needs to be off when drawing faceline/mask textures. */
+	lightEnable?: boolean;
+	/** Light direction. */
+	lightDirection?: Vector3;
+	/**
+	 * Whether to override specular mode on all materials with 0 (Blinn-Phong specular).
+	 */
+	useSpecularModeBlinn?: boolean;
+	/** Texture map. */
+	map?: Texture;
+};
+
+export default FFLShaderMaterialParameters;

--- a/src/materials/SampleShaderMaterialColorInfo.ts
+++ b/src/materials/SampleShaderMaterialColorInfo.ts
@@ -1,0 +1,10 @@
+type SampleShaderMaterialColorInfo = {
+	facelineColor: number;
+	favoriteColor: number;
+	hairColor: number;
+	beardColor: number;
+	/** PantsColor from ffl.js, 0-4. */
+	pantsColor: number;
+};
+
+export default SampleShaderMaterialColorInfo;

--- a/src/materials/TextureShaderMaterial.ts
+++ b/src/materials/TextureShaderMaterial.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { FFLModulateMode } from '../enums';
+import { FFLModulateMode } from '@/enums';
 
 /**
  * A material class that renders FFL swizzled (modulateMode) textures.

--- a/src/materials/TextureShaderMaterial.ts
+++ b/src/materials/TextureShaderMaterial.ts
@@ -1,0 +1,156 @@
+import * as THREE from 'three';
+import { FFLModulateMode } from '../enums';
+
+/**
+ * A material class that renders FFL swizzled (modulateMode) textures.
+ * Has no lighting whatsoever, just meant to render 2D planes.
+ * @augments {THREE.ShaderMaterial}
+ */
+export default class TextureShaderMaterial extends THREE.ShaderMaterial {
+	public lightEnable: boolean;
+	public modulateType: number;
+	public _color3?: THREE.Color;
+
+	/**
+	 * @typedef {Object} TextureShaderMaterialParameters
+	 * @property {FFLModulateMode} [modulateMode] - Modulate mode.
+	 * @property {FFLModulateType} [modulateType] - Modulate type.
+	 * @property {import('three').Color|Array<import('three').Color>} [color] -
+	 * Constant color assigned to u_const1/2/3 depending on single or array.
+	 */
+
+	/**
+	 * The material constructor.
+	 * @param {THREE.ShaderMaterialParameters & TextureShaderMaterialParameters} [options] -
+	 * Parameters for the material.
+	 */
+	constructor(options = {}) {
+		// Set default uniforms.
+		const uniforms: Record<string, THREE.IUniform> = {
+			opacity: { value: 1.0 }
+		};
+		const blankMatrix3 = { value: new THREE.Matrix3() };
+		if (Number(THREE.REVISION) < 151) {
+			uniforms.uvTransform = blankMatrix3;
+		} else {
+			uniforms.mapTransform = blankMatrix3;
+		}
+
+		// Construct the ShaderMaterial using the shader source.
+		super({
+			vertexShader: /* glsl */`
+				#include <common>
+				#include <uv_pars_vertex>
+
+				void main() {
+					#include <begin_vertex>
+					#include <uv_vertex>
+					#include <project_vertex>
+				}`,
+			fragmentShader: /* glsl */`
+				#include <common>
+				#include <uv_pars_fragment>
+				#include <map_pars_fragment>
+				uniform vec3 diffuse;
+				uniform float opacity;
+				uniform int modulateMode;
+				uniform vec3 color1;
+				uniform vec3 color2;
+
+				void main() {
+					vec4 diffuseColor = vec4( diffuse, opacity );
+
+					#include <map_fragment>
+					#include <alphamap_fragment>
+				#ifdef USE_MAP
+					if (modulateMode == 2) { // FFL_MODULATE_MODE_RGB_LAYERED
+					diffuseColor = vec4(
+					  diffuse.rgb * sampledDiffuseColor.r +
+					  color1.rgb * sampledDiffuseColor.g +
+					  color2.rgb * sampledDiffuseColor.b,
+					  sampledDiffuseColor.a
+					);
+				  } else if (modulateMode == 3) { // FFL_MODULATE_MODE_ALPHA
+					diffuseColor = vec4(
+					  diffuse.rgb * sampledDiffuseColor.r,
+					  sampledDiffuseColor.r
+					);
+				  } else if (modulateMode == 4) { // FFL_MODULATE_MODE_LUMINANCE_ALPHA
+					diffuseColor = vec4(
+					  diffuse.rgb * sampledDiffuseColor.g,
+					  sampledDiffuseColor.r
+					);
+				  } else if (modulateMode == 5) { // FFL_MODULATE_MODE_ALPHA_OPA
+					diffuseColor = vec4(
+					  diffuse.rgb * sampledDiffuseColor.r,
+					  1.0
+					);
+				  }
+				#endif
+
+				  // avoids little outline around mask elements
+				  if (modulateMode != 0 && diffuseColor.a == 0.0) { // FFL_MODULATE_MODE_CONSTANT
+					  discard;
+				  }
+
+					gl_FragColor = diffuseColor;
+					//#include <colorspace_fragment>
+				}`,
+			uniforms: uniforms
+		});
+		// Set defaults so that they are valid parameters.
+		this.lightEnable = false;
+		this.modulateType = 0;
+
+		// Use the setters to set the rest of the uniforms.
+		this.setValues(options);
+	}
+
+	/**
+	 * Gets the constant color (diffuse) uniform as THREE.Color.
+	 * @returns {import('three').Color|null} The constant color, or null if it is not set.
+	 */
+	get color(): THREE.Color | null {
+		return this.uniforms.diffuse ? this.uniforms.diffuse.value : null;
+	}
+
+	/**
+	 * Sets the constant color uniforms from THREE.Color.
+	 * @param {import('three').Color|Array<import('three').Color>} value -
+	 * The constant color (diffuse), or multiple (diffuse/color1/color2) to set the uniforms for.
+	 */
+	set color(value: THREE.Color | THREE.Color[]) {
+		// Set an array of colors, assumed to have 3 elements.
+		if (Array.isArray(value)) {
+			// Assign multiple color instances.
+			this.uniforms.diffuse = { value: value[0] };
+			this.uniforms.color1 = { value: value[1] };
+			this.uniforms.color2 = { value: value[2] };
+			return;
+		}
+		// Set single color as THREE.Color, defaulting to white.
+		const color3 = value ? value : new THREE.Color(1.0, 1.0, 1.0);
+		this._color3 = color3;
+		this.uniforms.diffuse = { value: color3 };
+	}
+
+	/** @returns {FFLModulateMode|null}The modulateMode value, or null if it is unset. */
+	get modulateMode(): FFLModulateMode | null {
+		return this.uniforms.modulateMode ? this.uniforms.modulateMode.value : null;
+	}
+
+	/** @param {FFLModulateMode} value - The new modulateMode value. */
+	set modulateMode(value: FFLModulateMode) {
+		this.uniforms.modulateMode = { value: value };
+	}
+
+	/** @returns {import('three').Texture|null}The texture map, or null if it is unset. */
+	get map(): THREE.Texture | null {
+		return this.uniforms.map ? this.uniforms.map.value : null;
+	}
+
+	/** @param {import('three').Texture} value - The new texture map. */
+	set map(value: THREE.Texture) {
+		this.uniforms.map = { value: value };
+	}
+}

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,0 +1,3 @@
+import type Renderer from 'three/src/renderers/common/Renderer.js';
+
+export default Renderer;

--- a/src/structs.ts
+++ b/src/structs.ts
@@ -1,0 +1,94 @@
+import type * as enums from './enums';
+
+/** Mirror for {@link _.uint32le} to indicate a pointer. */
+export const _uintptr = _.uint32le;
+
+/**
+ * @typedef {Object} FFLAttributeBuffer
+ * @property {number} size
+ * @property {number} stride
+ * @property {number} ptr
+ */
+/** @type {import('./struct-fu').StructInstance<FFLAttributeBuffer>} */
+export const FFLAttributeBuffer = _.struct([
+	_.uint32le('size'),
+	_.uint32le('stride'),
+	_uintptr('ptr')
+]);
+
+/**
+ * @typedef {Object} FFLPrimitiveParam
+ * @property {number} primitiveType
+ * @property {number} indexCount
+ * @property {number} pAdjustMatrix
+ * @property {number} pIndexBuffer
+ */
+/** @type {import('./struct-fu').StructInstance<FFLPrimitiveParam>} */
+export const FFLPrimitiveParam = _.struct([
+	_.uint32le('primitiveType'),
+	_.uint32le('indexCount'),
+	_uintptr('pAdjustMatrix'),
+	_uintptr('pIndexBuffer')
+]);
+
+/**
+ * @typedef {Object} FFLColor
+ * @property {number} r
+ * @property {number} g
+ * @property {number} b
+ * @property {number} a
+ */
+/** @type {import('./struct-fu').StructInstance<FFLColor>} */
+export const FFLColor = _.struct([
+	_.float32le('r'),
+	_.float32le('g'),
+	_.float32le('b'),
+	_.float32le('a')
+]);
+
+/**
+ * @typedef {Object} FFLVec3
+ * @property {number} x
+ * @property {number} y
+ * @property {number} z
+ */
+/** @type {import('./struct-fu').StructInstance<FFLVec3>} */
+export const FFLVec3 = _.struct([
+	_.float32le('x'),
+	_.float32le('y'),
+	_.float32le('z')
+]);
+
+/**
+ * @typedef {Object} FFLModulateParam
+ * @property {enums.FFLModulateMode} mode
+ * @property {enums.FFLModulateType} type
+ * @property {number} pColorR - Pointer to FFLColor
+ * @property {number} pColorG - Pointer to FFLColor
+ * @property {number} pColorB - Pointer to FFLColor
+ * @property {number} pTexture2D
+ */
+/** @type {import('./struct-fu').StructInstance<FFLModulateParam>} */
+export const FFLModulateParam = _.struct([
+	_.uint32le('mode'), // enum FFLModulateMode
+	_.uint32le('type'), // enum FFLModulateType
+	_uintptr('pColorR'),
+	_uintptr('pColorG'),
+	_uintptr('pColorB'),
+	_uintptr('pTexture2D')
+]);
+
+/**
+ * @typedef {Object} FFLDrawParam
+ * @property {Array<FFLAttributeBuffer>} attributeBuffers
+ * @property {FFLModulateParam} modulateParam
+ * @property {enums.FFLCullMode} cullMode
+ * @property {FFLPrimitiveParam} primitiveParam
+ */
+/** @type {import('./struct-fu').StructInstance<FFLDrawParam>} */
+export const FFLDrawParam = _.struct([
+	_.struct('attributeBuffers', [FFLAttributeBuffer], 5),
+	_.struct('modulateParam', [FFLModulateParam]),
+	_.uint32le('cullMode'),
+	_.struct('primitiveParam', [FFLPrimitiveParam])
+]);

--- a/src/structs.ts
+++ b/src/structs.ts
@@ -1,4 +1,4 @@
-import type * as enums from './enums';
+import * as _ from '../struct-fu.js';
 
 /** Mirror for {@link _.uint32le} to indicate a pointer. */
 export const _uintptr = _.uint32le;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,22 @@
 {
-  // https://github.com/microsoft/TypeScript/blob/1cd8e20f947513cc8c0c7c59e55b2f4524eff316/tests/baselines/reference/config/initTSConfig/Initialized%20TSConfig%20with%20advanced%20options/tsconfig.json#L7
   "compilerOptions": {
     "allowJs": true,
-    //"checkJs": true, // Assumed from @ts-check.
-    "target": "es2015", // but materials use ES2020 "??"
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "target": "es2015",
+    "module": "esnext",
+    "moduleResolution": "bundler",
 
     "strict": true,
     "noImplicitAny": true,
-    "noUnusedLocals": true, // TODO enable when exports are added
+    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": false,
 
     "skipLibCheck": true,
-    "declaration": true, // Generate only declarations.
-    //"declarationMap": true, // Emits .d.ts.map.
-    "emitDeclarationOnly": true,
-    "outDir": "dist" // Emit .d.ts into dist so it can be found by TypeScript.
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "exclude": ["dist/"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	format: ['esm', 'cjs'],
+	dts: true,
+	clean: true,
+	sourcemap: true
+});


### PR DESCRIPTION
This started off as just an attempt to split the code based on the `TODO` comments present in `ffl.js`, but then it evolved into a basic TypeScript port as well since it seemed like this library could benefit from real TypeScript support

Completely untested right now, not even building. Literally just ports the existing JavaScript into TypeScript as 1:1 as possible. The only changes are to get the TypeScript language server in VSCode to shut up, no actual functionality changes have been added

This should absolutely not be merged right now, the old code is left as a reference for now

## Changes (some of this might not be in scope for this PR tbf):

- [x] - Starts a port to TypeScript
- [x] - Addresses all of the `TODO` comments about code splitting, all code now lives in `src` split into the files the `TODO` comments named
- [x] - Add TypeScript build system (`tsup`?)
- [ ] - Port all the JSDoc type definitions to TypeScript types
- [ ] - Remove type annotations from JSDoc (TypeScript handles this)
- [ ] - Port the missing files from `materials`. Some of them, like `SampleShaderMaterial`, do some funky factory stuff that didn't want to trivially be ported to TypeScript as-is. These will likely require some larger changes to get working
- [ ] - Add eslint (maybe just reuse [`@pretendonetwork/eslint-config`](https://www.npmjs.com/package/@pretendonetwork/eslint-config)? I'd hate to dog-food like that and push our standards on another project, but the `README` did ask for scrutinization and our eslint config is based off 10+ years of working on Pretendo and other projects). ***EDIT: I didn't see the eslint config and it wasn't checking the `src` folder during the port, so I actually hadn't noticed eslint is already here. So this task can probably be removed?***
- [ ] - General refactoring? There's definitely a few areas in here that seem kinda smelly when it comes to the types/general structure of the code (such as in `updateCharModel` which turns off the TypeScript checker to update `charModel._model`, which is supposed to be `readonly`, and some areas do some odd line splitting and such?)
- [ ] - Maybe suggest moving from `struct-fu` to the custom parser present [here](https://github.com/PretendoNetwork/nintendo-file-formats/blob/b8a1104cb75bbe5a72e22187e09b43b84597d813/src/binary-parser.ts) (once it's broken out into it's own module)? Again I'd hate to dog-food like that, but `struct-fu` does seem to have some weird issues with type resolution here, I keep getting `StructInstance<any>` results everywhere when doing this port which lacks type safety, and structs have their types defined twice (once in `struct-fu` and once in JSDoc) which seems to be used for adding intellisense to unpacked data? This ends up taking up a TON of space in the files, especially in cases like `FFLiCharInfo`, and the parser I started writing was made with type safety/automatic type generation in mind which would fix that issue
- [ ] - Clean up imports and actually add consistency. The imports were done through a mix of manual writing and letting VSCode automatically add the imports, so things like the order of imports, the quote style, etc. are not consistent right now